### PR TITLE
fix(opencode): allow ~/.claude, ~/.codex, ~/.npm

### DIFF
--- a/opencode/policy.json
+++ b/opencode/policy.json
@@ -32,6 +32,9 @@
       "$HOME/.local/share/opencode",
       "$HOME/.local/share/opentui",
       "$HOME/.local/state/opencode",
+      "$HOME/.claude",
+      "$HOME/.codex",
+      "$HOME/.npm",
       "$NONO_CONFIG/profile-drafts",
       "$TMPDIR"
     ],


### PR DESCRIPTION
Allowing access to these directories is necessary in various circumstances:
- `.claude`: when the directory exists, OpenCode wants to read skills from it and write transcripts to it
- `.codex`: used for some LSP servers used for example by Oh My OpenAgent
- `.npm`: plugins tend to want to auto-update and unfortunately use npm