### PR TITLE
opencode: add session_hooks.before hook to `mkdir -p` state dirs before sandbox start

### DIFF
--- a/opencode/README.md
+++ b/opencode/README.md
@@ -9,6 +9,7 @@ It installs a sandbox profile, a TypeScript plugin, and a skill that make openco
 The pack provides:
 
 - a sandbox profile (`policy.json`) granting the correct filesystem and network access, with credential injection routes for OpenAI, Anthropic, Gemini, GitHub, and GitLab
+- a `session_hooks.before` hook (`bin/ensure-dirs.sh`) that creates opencode's state directories on the host before the sandbox is applied, so first-run doesn't fail when a directory the profile grants access to doesn't exist yet
 - a TypeScript plugin (`plugin/nono-sandbox.ts`) that injects nono sandbox context at session start, detects denial signatures in tool results, appends capability context and Option A/B remediation guidance, surfaces the network egress allowlist, and registers a `nono-status` command
 - a `nono-sandbox` skill that teaches the correct diagnostic flow for filesystem and network-egress denials, credential route setup, and detach/attach usage
 
@@ -25,6 +26,12 @@ When opencode is running inside a `nono` sandbox the installed plugin:
 - steers the model toward the two valid remediations: `--allow` restart or a persistent profile draft
 
 This prevents common bad guidance such as retrying the same action, suggesting `chmod`, attempting network workarounds, or treating the failure as a macOS TCC issue.
+
+## First-Run Directory Bootstrap
+
+Landlock and Seatbelt can only grant a filesystem rule for a path that already exists. On a first run, a few state/cache/etc. directories don't exist yet, so the sandboxed opencode process fails immediately.
+
+`policy.json` wires `bin/ensure-dirs.sh` as a `session_hooks.before` hook, which nono runs on the host before applying the sandbox to `mkdir -p` them first. Requires nono v0.63.0+ for `$PACK_DIR` expansion in `session_hooks`.
 
 ## Credential Injection
 

--- a/opencode/bin/ensure-dirs.sh
+++ b/opencode/bin/ensure-dirs.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# nono session_hooks.before script.
+#
+# Runs on the host with host privileges, before the sandbox is applied.
+# Landlock/Seatbelt can only grant a filesystem rule for a path that already
+# exists, so on first run (before opencode has ever created its state dirs)
+# every "$HOME/..." entry in policy.json's filesystem.allow list is missing
+# and the sandboxed opencode process fails to start. Create them here, before
+# the sandbox boundary goes up.
+set -euo pipefail
+
+mkdir -p \
+  "$HOME/.opencode" \
+  "$HOME/.config/opencode" \
+  "$HOME/.cache/opencode" \
+  "$HOME/.local/share/opencode" \
+  "$HOME/.local/share/opentui" \
+  "$HOME/.local/state/opencode"

--- a/opencode/package.json
+++ b/opencode/package.json
@@ -8,7 +8,7 @@
     "macos",
     "linux"
   ],
-  "min_nono_version": "0.55.0",
+  "min_nono_version": "0.63.0",
   "keywords": [
     "opencode",
     "nono",
@@ -30,6 +30,10 @@
     {
       "type": "plugin",
       "path": "plugin/nono-sandbox.ts"
+    },
+    {
+      "type": "plugin",
+      "path": "bin/ensure-dirs.sh"
     },
     {
       "type": "plugin",

--- a/opencode/policy.json
+++ b/opencode/policy.json
@@ -100,6 +100,12 @@
   "workdir": {
     "access": "readwrite"
   },
+  "session_hooks": {
+    "before": {
+      "script": "$PACK_DIR/bin/ensure-dirs.sh",
+      "timeout_secs": 10
+    }
+  },
   "open_urls": {
     "allow_origins": [
       "https://auth.openai.com",


### PR DESCRIPTION
Landlock and Seatbelt can only grant a filesystem rule for a path that already exists. On a first run, a few state/cache/etc. directories don't exist yet, so the sandboxed opencode process fails immediately.

`policy.json` wires `bin/ensure-dirs.sh` as a `session_hooks.before` hook, which nono runs on the host before applying the sandbox to `mkdir -p` them first. Requires nono v0.63.0+ for `$PACK_DIR` expansion in `session_hooks`.