### PR TITLE
feat(opencode): add AWS Bedrock SigV4/SSO credential routes per region

### DIFF
--- a/.github/workflows/pack-smoke-test.yml
+++ b/.github/workflows/pack-smoke-test.yml
@@ -34,7 +34,7 @@ jobs:
   detect:
     runs-on: ubuntu-latest
     outputs:
-      packs: ${{ steps.detect.outputs.packs }}
+      include: ${{ steps.detect.outputs.include }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -57,19 +57,41 @@ jobs:
           while read -r dir; do
             [[ -n "$dir" && -f "$dir/package.json" ]] && PACK_LIST+="$dir"$'\n'
           done <<< "$CHANGED"
-          PACKS=$(echo "$PACK_LIST" | jq -Rsc 'split("\n") | map(select(length > 0))')
 
-          echo "packs=$PACKS" >> "$GITHUB_OUTPUT"
-          echo "Changed packs: $PACKS"
+          # Build a {pack, os} matrix scoped to each pack's own declared `platforms`, so a
+          # single-OS pack (e.g. copilot-cli is macos-only, claude-autoresearch is
+          # linux-only) never gets a smoke-test job on an OS it doesn't claim to support —
+          # such a job would otherwise run every non-sandboxed check for real on a platform
+          # the pack was never validated against (sandboxed-execution checks specifically
+          # are separately skipped everywhere via NONO_SKIP_SANDBOX below; this matrix scope
+          # is about the rest of the smoke suite, not about that skip).
+          INCLUDE="[]"
+          while read -r dir; do
+            [[ -z "$dir" ]] && continue
+            PLATFORMS=$(jq -c '.platforms // ["macos", "linux"]' "$dir/package.json")
+            for platform in $(echo "$PLATFORMS" | jq -r '.[]'); do
+              case "$platform" in
+                macos) OS="macos-latest" ;;
+                linux) OS="ubuntu-latest" ;;
+                *)
+                  echo "Unknown platform '$platform' in $dir/package.json — fix the manifest" >&2
+                  exit 1
+                  ;;
+              esac
+              INCLUDE=$(echo "$INCLUDE" | jq -c --arg pack "$dir" --arg os "$OS" '. + [{"pack": $pack, "os": $os}]')
+            done
+          done <<< "$PACK_LIST"
+
+          echo "include=$INCLUDE" >> "$GITHUB_OUTPUT"
+          echo "Matrix include: $INCLUDE"
 
   smoke:
     needs: detect
-    if: needs.detect.outputs.packs != '[]' && needs.detect.outputs.packs != ''
+    if: needs.detect.outputs.include != '[]' && needs.detect.outputs.include != ''
     strategy:
       fail-fast: false
       matrix:
-        pack: ${{ fromJson(needs.detect.outputs.packs) }}
-        os: [ubuntu-latest, macos-latest]
+        include: ${{ fromJson(needs.detect.outputs.include) }}
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -112,6 +134,25 @@ jobs:
 
       - name: Run smoke tests
         env:
+          # `install-pack-local.sh` bypasses the registry entirely (by design, for local/CI
+          # testing) and writes lockfile entries with no signer identity / provenance. `nono
+          # run --profile <namespace>/<pack>` categorically refuses to start a sandboxed
+          # process against such an entry ("Package verification failed ... no signer
+          # identity in the lockfile"), independent of --trust-override or any other run-time
+          # flag found so far. Confirmed directly against nono 0.70.0: every sandboxed-
+          # execution assertion in scripts/smoke-test-pack.sh fails this way for every pack
+          # once this skip is removed. The root cause is CI's entire sandboxed-execution path
+          # being structurally incompatible with how packs get installed for testing here —
+          # but do not read that as "the credential-leak coverage gap is therefore not real":
+          # with this skip in place, the AWS credential-leak assertions in
+          # scripts/smoke-test-pack.sh get ZERO automated coverage in CI. They are verified
+          # correct only locally/manually (see PR discussion / session notes), with no CI
+          # enforcement until this is resolved. Re-enabling this requires either a nono CLI
+          # mechanism to accept sideloaded/unsigned packs at run time, or install-pack-local.sh
+          # writing whatever lockfile shape nono's package verification actually requires
+          # (unconfirmed — do not guess at that shape without checking against nono's own
+          # source/docs first; as of nono 0.70.0 there is no such shape — see nolabs-ai/nono
+          # issues #1188 and #1190, unmerged, which require a compile-time feature flag).
           NONO_SKIP_SANDBOX: "1"
         run: |
           bash scripts/smoke-test-pack.sh "always-further/${{ matrix.pack }}"

--- a/lib/test_helpers.sh
+++ b/lib/test_helpers.sh
@@ -3,8 +3,8 @@
 #
 # Sourced by test_registry_packs.sh. Provides:
 #   verify_nono_binary, setup_test_dir, cleanup_test_dir,
-#   expect_success, expect_output_contains, require_working_sandbox,
-#   print_summary
+#   expect_success, expect_output_contains, expect_output_not_contains,
+#   require_working_sandbox, print_summary
 
 NONO_BIN="${NONO_BIN:-nono}"
 
@@ -57,11 +57,34 @@ expect_output_contains() {
     local pattern="$2"
     shift 2
     local output
-    output=$("$@" 2>&1)
-    if echo "$output" | grep -qF "$pattern"; then
+    local rc=0
+    output=$("$@" 2>&1) || rc=$?
+    if [[ $rc -ne 0 ]]; then
+        _fail "$label" "command exited $rc — $(echo "$output" | head -3)"
+        return
+    fi
+    if grep -qF -- "$pattern" <<< "$output"; then
         _pass "$label"
     else
         _fail "$label" "pattern '$pattern' not found in output"
+    fi
+}
+
+expect_output_not_contains() {
+    local label="$1"
+    local pattern="$2"
+    shift 2
+    local output
+    local rc=0
+    output=$("$@" 2>&1) || rc=$?
+    if [[ $rc -ne 0 ]]; then
+        _fail "$label" "command exited $rc — cannot verify pattern absence: $(echo "$output" | head -3)"
+        return
+    fi
+    if grep -qF -- "$pattern" <<< "$output"; then
+        _fail "$label" "pattern unexpectedly found in output"
+    else
+        _pass "$label"
     fi
 }
 

--- a/opencode/README.md
+++ b/opencode/README.md
@@ -8,7 +8,7 @@ It installs a sandbox profile, a TypeScript plugin, and a skill that make openco
 
 The pack provides:
 
-- a sandbox profile (`policy.json`) granting the correct filesystem and network access, with credential injection routes for OpenAI, Anthropic, Gemini, GitHub, and GitLab
+- a sandbox profile (`policy.json`) granting the correct filesystem and network access, with credential injection routes for OpenAI, Anthropic, Gemini, GitHub, GitLab (opt-in), and AWS Bedrock (SigV4/SSO, one route per supported Region, active by default)
 - a `session_hooks.before` hook (`bin/ensure-dirs.sh`) that creates opencode's state directories on the host before the sandbox is applied, so first-run doesn't fail when a directory the profile grants access to doesn't exist yet
 - a TypeScript plugin (`plugin/nono-sandbox.ts`) that injects nono sandbox context at session start, detects denial signatures in tool results, appends capability context and Option A/B remediation guidance, surfaces the network egress allowlist, and registers a `nono-status` command
 - a `nono-sandbox` skill that teaches the correct diagnostic flow for filesystem and network-egress denials, credential route setup, and detach/attach usage
@@ -35,7 +35,7 @@ Landlock and Seatbelt can only grant a filesystem rule for a path that already e
 
 ## Credential Injection
 
-nono intercepts outbound HTTPS and injects API keys from its keychain — opencode never sees the raw secret. Routes are defined in the profile but **disabled by default**.
+nono intercepts outbound HTTPS and injects API keys from its keychain — opencode never sees the raw secret. Routes other than `bedrock_<region>` (see below) are defined in the profile but **disabled by default**.
 
 To enable a route, create an extending profile:
 
@@ -51,12 +51,39 @@ Built-in route names: `openai`, `anthropic`, `gemini`, `github`, `gitlab`.
 
 Store the corresponding secret in the nono keychain under the env-var-shaped account name (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.).
 
+## AWS Bedrock (SigV4 / SSO)
+
+The `bedrock_*` routes work differently from the static-key routes above. Instead of injecting a header from a stored secret, nono intercepts the request and re-signs it with real AWS SigV4 credentials from the standard AWS credential chain, including SSO profiles. This needs `nono` 0.70.0 or later. Earlier versions have a signing bug for any Bedrock model ID with a colon in it ([nolabs-ai/nono#1430](https://github.com/nolabs-ai/nono/pull/1430), which is every standard model ID), and 0.69.0 on its own has a separate regression that breaks all non-Bedrock traffic on an open-network profile like this one ([#1485](https://github.com/nolabs-ai/nono/issues/1485), fixed in [#1497](https://github.com/nolabs-ai/nono/pull/1497)).
+
+SigV4 signatures are tied to a region, so there's one route per Bedrock region instead of a single `bedrock` route. Route names follow `bedrock_<region>`, for example `bedrock_us_east_1` or `bedrock_eu_west_1`. Check `network.custom_credentials` in `policy.json`, or run `nono profile show opencode`, for the full list, and match it against the [official Bedrock endpoint list](https://docs.aws.amazon.com/general/latest/gr/bedrock.html) for your region. GovCloud routes (`bedrock_us_gov_east_1`, `bedrock_us_gov_west_1`) need a separate GovCloud account and won't resolve from a commercial SSO profile.
+
+Unlike the routes above, every `bedrock_<region>` route is active by default, listed directly in the base profile's own `network.credentials`. There's no secret to protect by gating activation. `aws_auth` just resolves whatever AWS credentials are already on the host at request time (env vars, the default profile, an active `aws sso login` session, an instance role), and fails the same way an unsandboxed call would if none exist. As long as you're logged in and opencode's `amazon-bedrock` provider points at a matching region, it just signs the request. You don't need an extending profile for that.
+
+To pin a specific AWS profile instead of the default chain, override `aws_auth.profile` in an extending profile. The override replaces the whole entry, so you need to repeat `upstream` too, even though only `aws_auth` actually changes:
+
+```json
+{
+  "extends": "opencode",
+  "meta": { "name": "opencode-with-bedrock", "version": "1.0.0" },
+  "network": {
+    "custom_credentials": {
+      "bedrock_us_east_1": {
+        "upstream": "https://bedrock-runtime.us-east-1.amazonaws.com",
+        "aws_auth": { "profile": "my-sso-profile" }
+      }
+    }
+  }
+}
+```
+
+The base profile also denies `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_PROFILE`, and every other AWS credential variable, including legacy SDK aliases (`AWS_CONTAINER_*`, `AWS_WEB_IDENTITY_TOKEN_FILE`, `AWS_ROLE_*`, `AWS_CONFIG_FILE`, `AWS_SHARED_CREDENTIALS_FILE`, `AWS_ACCESS_KEY`, `AWS_SECRET_KEY`, `AWS_SECURITY_TOKEN`, `AWS_CREDENTIAL_FILE`), with phantom values for the access key pair and `AWS_EC2_METADATA_DISABLED=true` to block the instance metadata fallback too. opencode's AWS SDK only ever sees the phantoms, or nothing. nono strips whatever it sent and substitutes the real signature before the request leaves the proxy. You don't need a keychain entry here either, since credentials come straight from the host's AWS config, read by the unsandboxed proxy.
+
 ## Detach and Attach
 
 Run opencode in a detached session that survives terminal disconnects:
 
 ```bash
-nono run --profile opencode --detach -- opencode
+nono run --profile opencode --detached -- opencode
 ```
 
 Reattach from any terminal:
@@ -92,7 +119,7 @@ nono remove nolabs-ai/opencode
 ## Package Metadata
 
 - Name: `opencode`
-- Version: `0.0.6`
+- Version: `0.2.0`
 - Pack type: `agent`
 - Platforms: `macos`, `linux`
 - License: `Apache-2.0`

--- a/opencode/package.json
+++ b/opencode/package.json
@@ -1,21 +1,24 @@
 {
   "schema_version": 1,
   "name": "opencode",
-  "version": "0.1.0",
-  "description": "opencode plugin and matching nono profile. Provides sandbox-aware diagnostics, credential injection, detach/attach support, and a nono-status command when running inside a nono sandbox.",
+  "version": "0.2.0",
+  "description": "opencode plugin and matching nono profile. Provides sandbox-aware diagnostics, credential injection (including AWS SigV4/SSO signing), detach/attach support, and a nono-status command when running inside a nono sandbox.",
   "license": "Apache-2.0",
   "platforms": [
     "macos",
     "linux"
   ],
-  "min_nono_version": "0.63.0",
+  "min_nono_version": "0.70.0",
   "keywords": [
     "opencode",
     "nono",
     "sandbox",
     "security",
     "capabilities",
-    "credentials"
+    "credentials",
+    "aws",
+    "bedrock",
+    "sso"
   ],
   "artifacts": [
     {

--- a/opencode/plugin/nono-sandbox.ts
+++ b/opencode/plugin/nono-sandbox.ts
@@ -5,12 +5,24 @@ const DENIAL_PATTERN =
 
 const PATH_RE = /(?:~\/|\/)[^\s"'`,;:]+/
 
-type CredentialRoute = {
+// Static routes (openai, anthropic, gemini, github, gitlab) always carry
+// both credential_key and inject_header.
+// aws_auth routes (bedrock_<region>) carry neither — nono resolves and signs with real
+// AWS credentials instead of injecting a stored key. The two shapes are mutually
+// exclusive on every route this pack defines.
+type StaticCredentialRoute = {
   upstream: string
   credential_key: string
   inject_header: string
   env_var?: string
 }
+
+type AwsAuthCredentialRoute = {
+  upstream: string
+  aws_auth: { profile?: string; region?: string; service?: string }
+}
+
+type CredentialRoute = StaticCredentialRoute | AwsAuthCredentialRoute
 
 type Caps = {
   fs?: Array<{ path: string; resolved?: string; access: string }>
@@ -55,23 +67,74 @@ function profileDraftsDir(): string {
 function buildCredentialLines(caps: Caps): string {
   const routes = caps.credentials ?? {}
   const keys = Object.keys(routes)
-  if (keys.length === 0) return "  (none enabled — add routes to network.credentials in your profile)"
+  if (keys.length === 0) {
+    // NONO_CAP_FILE never populates `credentials` on nono 0.69.0/0.70.0, even with
+    // custom_credentials active, so this branch always runs. Don't claim "none enabled"
+    // — with bedrock_* active by default that's false. Revisit if nono starts reporting it.
+    return "  (not reported by this nono version — check network.credentials in policy.json for active routes)"
+  }
   return keys
     .map(name => {
+      // NONO_CAP_FILE is parsed from an external file at runtime (readCaps) and isn't
+      // schema-validated against CredentialRoute, so `r` may be null, a primitive, or an
+      // object shaped like neither known route type. Guard before any property access —
+      // the `in` operator throws on null/non-object operands.
       const r = routes[name]
-      const envVar = r.env_var ?? r.credential_key
-      const present = Boolean(process.env[envVar])
-      return `  ${name}: ${r.upstream}  [${present ? "key present" : "key missing — set " + envVar}]`
+      if (r === null || typeof r !== "object") {
+        return `  ${name}: [misconfigured — route entry is not an object]`
+      }
+
+      const hasAwsAuth =
+        "aws_auth" in r && typeof r.aws_auth === "object" && r.aws_auth !== null && !Array.isArray(r.aws_auth)
+      const hasCredentialKey = "credential_key" in r && typeof r.credential_key === "string" && r.credential_key !== ""
+      const upstream = typeof r.upstream === "string" ? r.upstream : "<unknown upstream>"
+
+      if (hasAwsAuth && hasCredentialKey) {
+        // The two route shapes are mutually exclusive by design (see the type comment
+        // above). A route carrying both is malformed data, not a valid aws_auth route —
+        // report it as invalid rather than silently picking one mechanism over the other.
+        return `  ${name}: ${upstream}  [misconfigured — route defines both aws_auth and credential_key]`
+      }
+
+      if (hasAwsAuth) {
+        // Report whether a profile is pinned without echoing its name: this text can be
+        // appended to tool-call results that flow back into the model's context, and a
+        // profile name may be an internal alias the user doesn't want sent to a model provider.
+        const desc =
+          typeof r.aws_auth.profile === "string" && r.aws_auth.profile !== ""
+            ? "SigV4 signed via a pinned AWS profile"
+            : "SigV4 signed via default AWS credential chain (supports SSO)"
+        return `  ${name}: ${upstream}  [${desc}]`
+      }
+      if (hasCredentialKey) {
+        // env_var must also be a non-empty string — it's used as a process.env lookup key
+        // below, and a malformed non-string value from an unvalidated NONO_CAP_FILE could
+        // otherwise reach that indexing operation.
+        const envVar =
+          typeof r.env_var === "string" && r.env_var !== "" ? r.env_var : r.credential_key
+        const present = Boolean(process.env[envVar])
+        return `  ${name}: ${upstream}  [${present ? "key present" : "key missing — set " + envVar}]`
+      }
+      return `  ${name}: ${upstream}  [misconfigured — no credential mechanism defined]`
     })
     .join("\n")
 }
+
+// This pack activates several bedrock_<region> credential routes by default (see
+// policy.json's network.credentials). On nono < 0.70.0 that alone silently narrows an
+// otherwise-open network policy to only those routes' upstream hosts, while
+// NONO_CAP_FILE still reports an empty allowlist (nolabs-ai/nono#1485, fixed in #1497 /
+// v0.70.0). Without this caveat, buildEgressGuidance/buildStatusReport would tell the
+// model "all outbound network is allowed" on exactly the versions where that's false.
+const STALE_ALLOWLIST_CAVEAT =
+  "Caveat: on nono older than 0.70.0, this pack's active AWS Bedrock credential routes can silently narrow this to only the Bedrock hosts (nolabs-ai/nono#1485, fixed in v0.70.0), even though this report says otherwise. If a non-Bedrock request unexpectedly fails despite this message, run `nono --version` and upgrade before concluding the connection is genuinely blocked."
 
 function buildDomainLines(caps: Caps): string {
   const domains = caps.allowed_domains ?? []
   if (domains.length === 0) {
     return caps.net_blocked
       ? "  (all outbound network blocked)"
-      : "  (no allowlist — all outbound network allowed)"
+      : "  (no allowlist reported — all outbound network should be allowed; " + STALE_ALLOWLIST_CAVEAT + ")"
   }
   return domains.map(d => "  " + d).join("\n")
 }
@@ -82,7 +145,7 @@ function buildEgressGuidance(caps: Caps): string {
     return "All outbound network is blocked. Retries, alternate endpoints, or proxies cannot bypass this — do not attempt workarounds."
   }
   if (domains.length === 0) {
-    return "No host allowlist is in effect; all outbound network is allowed."
+    return "No host allowlist is reported; all outbound network should be allowed. " + STALE_ALLOWLIST_CAVEAT
   }
   return [
     "Network egress is default-deny; only these hosts are reachable. Any other outbound connection fails by design — retries, alternate endpoints, or proxies cannot bypass it, so do not attempt workarounds:",

--- a/opencode/policy.json
+++ b/opencode/policy.json
@@ -56,7 +56,30 @@
   "network": {
     "block": false,
     "allow_domain": [],
-    "credentials": [],
+    "credentials": [
+      "bedrock_us_east_1",
+      "bedrock_us_east_2",
+      "bedrock_us_west_2",
+      "bedrock_ca_central_1",
+      "bedrock_sa_east_1",
+      "bedrock_eu_west_1",
+      "bedrock_eu_west_2",
+      "bedrock_eu_west_3",
+      "bedrock_eu_central_1",
+      "bedrock_eu_central_2",
+      "bedrock_eu_north_1",
+      "bedrock_eu_south_1",
+      "bedrock_eu_south_2",
+      "bedrock_ap_south_1",
+      "bedrock_ap_south_2",
+      "bedrock_ap_southeast_1",
+      "bedrock_ap_southeast_2",
+      "bedrock_ap_northeast_1",
+      "bedrock_ap_northeast_2",
+      "bedrock_ap_northeast_3",
+      "bedrock_us_gov_east_1",
+      "bedrock_us_gov_west_1"
+    ],
     "open_port": [],
     "listen_port": [],
     "custom_credentials": {
@@ -94,7 +117,118 @@
         "inject_header": "Authorization",
         "credential_format": "Bearer {}",
         "env_var": "GITLAB_TOKEN"
+      },
+      "bedrock_us_east_1": {
+        "upstream": "https://bedrock-runtime.us-east-1.amazonaws.com",
+        "aws_auth": {}
+      },
+      "bedrock_us_east_2": {
+        "upstream": "https://bedrock-runtime.us-east-2.amazonaws.com",
+        "aws_auth": {}
+      },
+      "bedrock_us_west_2": {
+        "upstream": "https://bedrock-runtime.us-west-2.amazonaws.com",
+        "aws_auth": {}
+      },
+      "bedrock_ca_central_1": {
+        "upstream": "https://bedrock-runtime.ca-central-1.amazonaws.com",
+        "aws_auth": {}
+      },
+      "bedrock_sa_east_1": {
+        "upstream": "https://bedrock-runtime.sa-east-1.amazonaws.com",
+        "aws_auth": {}
+      },
+      "bedrock_eu_west_1": {
+        "upstream": "https://bedrock-runtime.eu-west-1.amazonaws.com",
+        "aws_auth": {}
+      },
+      "bedrock_eu_west_2": {
+        "upstream": "https://bedrock-runtime.eu-west-2.amazonaws.com",
+        "aws_auth": {}
+      },
+      "bedrock_eu_west_3": {
+        "upstream": "https://bedrock-runtime.eu-west-3.amazonaws.com",
+        "aws_auth": {}
+      },
+      "bedrock_eu_central_1": {
+        "upstream": "https://bedrock-runtime.eu-central-1.amazonaws.com",
+        "aws_auth": {}
+      },
+      "bedrock_eu_central_2": {
+        "upstream": "https://bedrock-runtime.eu-central-2.amazonaws.com",
+        "aws_auth": {}
+      },
+      "bedrock_eu_north_1": {
+        "upstream": "https://bedrock-runtime.eu-north-1.amazonaws.com",
+        "aws_auth": {}
+      },
+      "bedrock_eu_south_1": {
+        "upstream": "https://bedrock-runtime.eu-south-1.amazonaws.com",
+        "aws_auth": {}
+      },
+      "bedrock_eu_south_2": {
+        "upstream": "https://bedrock-runtime.eu-south-2.amazonaws.com",
+        "aws_auth": {}
+      },
+      "bedrock_ap_south_1": {
+        "upstream": "https://bedrock-runtime.ap-south-1.amazonaws.com",
+        "aws_auth": {}
+      },
+      "bedrock_ap_south_2": {
+        "upstream": "https://bedrock-runtime.ap-south-2.amazonaws.com",
+        "aws_auth": {}
+      },
+      "bedrock_ap_southeast_1": {
+        "upstream": "https://bedrock-runtime.ap-southeast-1.amazonaws.com",
+        "aws_auth": {}
+      },
+      "bedrock_ap_southeast_2": {
+        "upstream": "https://bedrock-runtime.ap-southeast-2.amazonaws.com",
+        "aws_auth": {}
+      },
+      "bedrock_ap_northeast_1": {
+        "upstream": "https://bedrock-runtime.ap-northeast-1.amazonaws.com",
+        "aws_auth": {}
+      },
+      "bedrock_ap_northeast_2": {
+        "upstream": "https://bedrock-runtime.ap-northeast-2.amazonaws.com",
+        "aws_auth": {}
+      },
+      "bedrock_ap_northeast_3": {
+        "upstream": "https://bedrock-runtime.ap-northeast-3.amazonaws.com",
+        "aws_auth": {}
+      },
+      "bedrock_us_gov_east_1": {
+        "upstream": "https://bedrock-runtime.us-gov-east-1.amazonaws.com",
+        "aws_auth": {}
+      },
+      "bedrock_us_gov_west_1": {
+        "upstream": "https://bedrock-runtime.us-gov-west-1.amazonaws.com",
+        "aws_auth": {}
       }
+    }
+  },
+  "environment": {
+    "deny_vars": [
+      "AWS_ACCESS_KEY_ID",
+      "AWS_SECRET_ACCESS_KEY",
+      "AWS_SESSION_TOKEN",
+      "AWS_PROFILE",
+      "AWS_BEARER_TOKEN_BEDROCK",
+      "AWS_CONTAINER_*",
+      "AWS_WEB_IDENTITY_TOKEN_FILE",
+      "AWS_ROLE_*",
+      "AWS_CONFIG_FILE",
+      "AWS_SHARED_CREDENTIALS_FILE",
+      "AWS_ACCESS_KEY",
+      "AWS_SECRET_KEY",
+      "AWS_SECURITY_TOKEN",
+      "AWS_CREDENTIAL_FILE"
+    ],
+    "set_vars": {
+      "AWS_ACCESS_KEY_ID": "nono-phantom-access-key",
+      "AWS_SECRET_ACCESS_KEY": "nono-phantom-secret-key",
+      "AWS_EC2_METADATA_DISABLED": "true"
     }
   },
   "workdir": {

--- a/opencode/skills/nono-sandbox/SKILL.md
+++ b/opencode/skills/nono-sandbox/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nono-sandbox
 description: Diagnose and resolve permission denials when opencode runs inside a nono security sandbox. Use this when a tool call, shell command, or file operation fails with "Operation not permitted", "Permission denied", EACCES, EPERM, landlock, or sandbox-denied errors, or when an outbound network request fails because the host is not on the sandbox allowlist (connection refused, timeout, or proxy/TLS errors).
-version: 1.2.0
+version: 1.3.0
 platforms: [macos, linux]
 ---
 
@@ -116,7 +116,7 @@ Then tell the user to run `nono profile promote <chosen-name>` and start session
 
 The opencode nono profile defines credential routes for common AI providers. nono injects these credentials transparently via its proxy — opencode never sees the raw API key.
 
-Built-in route names: `openai`, `anthropic`, `gemini`, `github`, `gitlab`.
+Built-in route names: `openai`, `anthropic`, `gemini`, `github`, `gitlab`, and one `bedrock_<region>` route per Bedrock-supported AWS Region (e.g. `bedrock_us_east_1`, `bedrock_eu_west_1`) — inspect `network.custom_credentials` in `policy.json`, or run `nono profile show opencode`, for the exact list.
 
 The corresponding keychain accounts (env-var shaped) are:
 - `OPENAI_API_KEY` → injected as `Authorization: Bearer …` to `api.openai.com`
@@ -125,7 +125,9 @@ The corresponding keychain accounts (env-var shaped) are:
 - `GITHUB_TOKEN` → injected as `Authorization: token …` to `api.github.com`
 - `GITLAB_TOKEN` → injected as `Authorization: Bearer …` to `gitlab.com/api`
 
-Routes are defined in the profile but **disabled by default**. To enable one, create an extending profile and add the route name to `network.credentials`:
+`bedrock_<region>` routes are different: they have no keychain entry, and unlike the routes above, they are **active by default** (listed in the base profile's own `network.credentials`, not opt-in). They use AWS SigV4 request signing instead of header injection — nono resolves real AWS credentials (including SSO profiles) from the host's AWS credential chain and re-signs the request. SigV4 signatures are region-pinned, so pick the route matching your Bedrock region by pointing opencode's `amazon-bedrock` provider at that region — no extending profile is needed just to reach Bedrock. The profile denies real `AWS_*` env vars from reaching the sandbox and substitutes phantom placeholders so the AWS SDK inside opencode still attempts the call for nono to intercept and sign.
+
+Routes other than `bedrock_<region>` are defined in the profile but **disabled by default**. To enable one, create an extending profile and add the route name to `network.credentials`:
 
     {
       "extends": "opencode",
@@ -139,7 +141,7 @@ Do not read or write API keys directly from inside the sandbox. Prefer nono phan
 
 nono supports running opencode in a detached session that survives terminal disconnects:
 
-    nono run --profile opencode --detach -- opencode
+    nono run --profile opencode --detached -- opencode
 
 nono prints the session ID on start. Reattach from any terminal:
 

--- a/scripts/install-pack-local.sh
+++ b/scripts/install-pack-local.sh
@@ -109,8 +109,21 @@ ENTRY=$(jq -n \
 
 PACK_KEY="$NAMESPACE/$PACK_NAME"
 tmp=$(mktemp)
+# Merge (rather than replace) the pack's lockfile entry: a prior real `nono pull` of this
+# same pack may have recorded a `provenance`/signer-identity field this script never writes
+# (it deliberately bypasses the registry, so it has none to write). A plain replace would
+# silently destroy that field on every local re-install. This does not make a locally-built
+# pack pass nono's package verification on its own — that still requires a genuine Sigstore
+# bundle matching the installed files — it only avoids gratuitously erasing pre-existing
+# lockfile metadata that belongs to a separate, real registry install.
+#
+# Deliberately `+` (shallow merge), not `*` (recursive merge): every field `$entry` defines
+# — including `artifacts` — must be replaced wholesale, not merged key-by-key. `*` would
+# recursively merge the `artifacts` sub-object, letting an artifact removed or renamed since
+# the last install linger in the lockfile under its old (now-stale) sha256. `+` only carries
+# forward fields `$entry` doesn't mention at all, which is exactly `provenance`.
 jq --arg key "$PACK_KEY" --argjson entry "$ENTRY" \
-    '.packages[$key] = $entry' "$LOCKFILE" > "$tmp"
+    '.packages[$key] = ((.packages[$key] // {}) + $entry)' "$LOCKFILE" > "$tmp"
 mv "$tmp" "$LOCKFILE"
 
 echo "Done. Pack registered as '$PACK_KEY' in $LOCKFILE"

--- a/scripts/smoke-test-pack.sh
+++ b/scripts/smoke-test-pack.sh
@@ -71,4 +71,67 @@ if require_working_sandbox "sandboxed execution"; then
         bash -lc "cd \"$TMPDIR/workdir\" && \"$NONO_BIN_ABS\" run --profile \"$PACK\" --allow-cwd --no-audit -- echo smoke"
 fi
 
+if [[ "$name" == "opencode" ]]; then
+    echo "AWS credential route handling (opencode only)"
+
+    expect_output_contains "profile show $PACK lists a bedrock credential route" "bedrock_" \
+        "$NONO_BIN" profile show "$PACK"
+
+    if require_working_sandbox "AWS credential phantom substitution"; then
+        NONO_BIN_ABS="$(cd "$(dirname "$NONO_BIN")" && pwd)/$(basename "$NONO_BIN")"
+
+        # Sentinel values deliberately avoid AWS's real credential-value shapes (e.g. the
+        # "AKIA" access-key-ID prefix) so they can never be mistaken for a genuine leaked
+        # secret by GitHub's or any other secret scanner watching this repo's CI output.
+        # Capture ONE sandboxed `env` execution and assert everything against that single
+        # output — running one assertion per `nono run` invocation let a crashed/partial
+        # run silently skip coverage for whichever assertion didn't happen to run last.
+        sandboxed_aws_env() {
+            AWS_ACCESS_KEY_ID="NONO-SMOKE-TEST-LEAK-SENTINEL-ACCESS-KEY-ID" \
+            AWS_SECRET_ACCESS_KEY="NONO-SMOKE-TEST-LEAK-SENTINEL-SECRET-KEY" \
+            AWS_ACCESS_KEY="NONO-SMOKE-TEST-LEAK-SENTINEL-LEGACY-ACCESS-KEY" \
+            AWS_SECRET_KEY="NONO-SMOKE-TEST-LEAK-SENTINEL-LEGACY-SECRET-KEY" \
+            AWS_SECURITY_TOKEN="NONO-SMOKE-TEST-LEAK-SENTINEL-SECURITY-TOKEN" \
+            AWS_CREDENTIAL_FILE="/tmp/nono-smoke-test-leak-sentinel-credential-file" \
+            bash -lc "cd \"$TMPDIR/workdir\" && \"$NONO_BIN_ABS\" run --profile \"$PACK\" --allow-cwd --no-audit -- env && echo NONO-SMOKE-TEST-ENV-DUMP-COMPLETE"
+        }
+
+        # The `|| SANDBOXED_ENV_RC=$?` form (rather than a bare `$?` on the next line) is
+        # required under `set -e`: without it, a nonzero exit from the command substitution
+        # aborts the whole script right here instead of letting us record and assert on it.
+        SANDBOXED_ENV_RC=0
+        SANDBOXED_ENV_OUTPUT="$(sandboxed_aws_env 2>&1)" || SANDBOXED_ENV_RC=$?
+
+        if [[ $SANDBOXED_ENV_RC -ne 0 ]] || ! grep -qF -- "NONO-SMOKE-TEST-ENV-DUMP-COMPLETE" <<< "$SANDBOXED_ENV_OUTPUT"; then
+            _fail "sandboxed env dump under $PACK completed successfully" \
+                "command exited $SANDBOXED_ENV_RC or completion marker missing — $(echo "$SANDBOXED_ENV_OUTPUT" | head -3)"
+        else
+            _pass "sandboxed env dump under $PACK completed successfully"
+
+            for leaked_value in \
+                "NONO-SMOKE-TEST-LEAK-SENTINEL-ACCESS-KEY-ID" \
+                "NONO-SMOKE-TEST-LEAK-SENTINEL-SECRET-KEY" \
+                "NONO-SMOKE-TEST-LEAK-SENTINEL-LEGACY-ACCESS-KEY" \
+                "NONO-SMOKE-TEST-LEAK-SENTINEL-LEGACY-SECRET-KEY" \
+                "NONO-SMOKE-TEST-LEAK-SENTINEL-SECURITY-TOKEN" \
+                "/tmp/nono-smoke-test-leak-sentinel-credential-file"
+            do
+                if grep -qF -- "$leaked_value" <<< "$SANDBOXED_ENV_OUTPUT"; then
+                    _fail "sandboxed process under $PACK never sees real value '$leaked_value'" \
+                        "pattern unexpectedly found in output"
+                else
+                    _pass "sandboxed process under $PACK never sees real value '$leaked_value'"
+                fi
+            done
+
+            if grep -qF -- "AWS_ACCESS_KEY_ID=nono-phantom-access-key" <<< "$SANDBOXED_ENV_OUTPUT"; then
+                _pass "sandboxed process under $PACK sees the phantom AWS_ACCESS_KEY_ID instead"
+            else
+                _fail "sandboxed process under $PACK sees the phantom AWS_ACCESS_KEY_ID instead" \
+                    "phantom value not found in output"
+            fi
+        fi
+    fi
+fi
+
 print_summary


### PR DESCRIPTION
Adds one bedrock_<region> custom-credential route per Bedrock-supported AWS Region (per AWS's official endpoint list), using the new aws_auth SigV4 signing feature (nolabs-ai/nono#1166, nolabs-ai/nono#1195). Real AWS creds never enter the sandbox. environment.deny_vars/set_vars strip them and substitute phantom placeholders, and nono re-signs the request on the way out.

Bumps min_nono_version to 0.70.0, since 0.67.0 turned out not to be enough (see README for the SigV4 colon-in-model-ID bug and the 0.69.0 network regression this needed to wait out).

Docs updated in README/SKILL.md with the route-lookup pointer (network.custom_credentials or nono profile show opencode) and usage examples.