### PR TITLE
fix(antigravity): enable read-write access to workdir

### DIFF
--- a/antigravity/policy.json
+++ b/antigravity/policy.json
@@ -77,7 +77,7 @@
   "env_credentials": {},
   "environment": null,
   "workdir": {
-    "access": "none"
+    "access": "readwrite"
   },
   "hooks": {},
   "session_hooks": {},


### PR DESCRIPTION
```markdown
   ## Summary

   - Change the Antigravity profile's `workdir.access` from `none` to `readwrite`.
   - Allow Antigravity to start in and operate on the project directory from which it was launched.
   - Align the profile with the Claude and Codex profiles, which both use read-write workdir access.

   ## Problem

   The Antigravity profile currently declares:

   ```json
   "workdir": {
     "access": "none"
   }
   ```

   When the launch directory is not covered by another filesystem capability, nono cannot use it as the sandboxed process's working directory and falls back to `/`.

   ```console
   $ cd /path/to/project
   $ nono run --profile antigravity -- pwd
   /
   ```

   Antigravity also cannot read or modify the project unless the user adds an explicit grant such as `--allow "$PWD"`.

   ## Change

   ```diff
   "workdir": {
   -  "access": "none"
   +  "access": "readwrite"
   }
   ```

   ## Verification

   Validated with nono 0.69.0:

   ```console
   $ nono profile validate antigravity/policy.json
   Result: valid

   $ cd /path/to/project
   $ nono run --profile antigravity --allow-cwd -- pwd
   /path/to/project
   ```