### PR TITLE
fix(opencode): avoid registering "execute" tool

### DIFF
--- a/opencode/plugin/nono-sandbox.ts
+++ b/opencode/plugin/nono-sandbox.ts
@@ -182,11 +182,13 @@ function buildStatusReport(caps: Caps | null): string {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function appendGuidance(result: any, guidance: string): unknown {
-  if (!result || typeof result !== "object") return result
+function appendGuidance(result: any, guidance: string): void {
+  if (!result || typeof result !== "object") return
   const r = result as Record<string, unknown>
+
   if (typeof r.content === "string") {
-    return { ...r, content: r.content + guidance }
+    r.output += guidance
+    return
   }
   if (Array.isArray(r.content)) {
     const parts = [...r.content]
@@ -201,46 +203,57 @@ function appendGuidance(result: any, guidance: string): unknown {
     } else {
       parts.push({ type: "text", text: guidance })
     }
-    return { ...r, content: parts }
+    r.content = parts
   }
-  return result
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const NonoSandboxPlugin = async (ctx: any) => {
+// eslint-disable-next-line
+export const NonoSandboxPlugin = async () => {
   if (!insideNono()) return {}
 
   const caps = readCaps()
 
-  // Register nono-status command if the context supports it
-  if (ctx && typeof ctx.registerCommand === "function") {
-    ctx.registerCommand("nono-status", {
-      description: "Show nono sandbox status for this opencode session",
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      handler: async (_args: any) => buildStatusReport(readCaps()),
-    })
-  }
-
   return {
     // Inject nono context into the system prompt so the model knows the rules
-    // before the first tool call. Fall back gracefully if opencode's plugin API
-    // doesn't support this field yet.
-    ...(caps ? { system: { inject: buildSystemContext(caps) } } : {}),
+    ...(caps
+      ? {
+          "experimental.chat.system.transform": async (
+            _input: unknown,
+            output: { system: string[] },
+          ) => {
+            output.system.push(buildSystemContext(caps))
+          },
+        }
+      : {}),
 
-    "tool.execute.description": "Internal middleware hook for the nono sandbox interception layer. Do not invoke directly.",
+    // Custom tool nono_status that outputs caps
+    tool: {
+      nono_status: {
+        description: "Show nono sandbox status for this opencode session",
+        args: {},
+        execute: async () => ({
+          title: "nono sandbox status",
+          output: buildStatusReport(readCaps()),
+        }),
+      },
+    },
+
     // Fires after every tool call. When the result contains a denial
     // signature we append capability context and Option A/B remediation.
-    "tool.execute.after": async (input: unknown, result: unknown) => {
-      if (!DENIAL_PATTERN.test(JSON.stringify(result))) return result
+    "tool.execute.after": async (
+      input: { tool: string; sessionID: string; callID: string; args: unknown },
+      result: unknown,
+    ) => {
+      if (!DENIAL_PATTERN.test(JSON.stringify(result))) return
 
       const liveCaps = readCaps()
-      if (!liveCaps) return result
+      if (!liveCaps) return
 
       const inputText = JSON.stringify(input)
       const resultText = JSON.stringify(result)
       const blockedPath = extractPath(inputText) ?? extractPath(resultText)
 
-      return appendGuidance(result, buildGuidance(liveCaps, blockedPath))
+      appendGuidance(result, buildGuidance(liveCaps, blockedPath))
     },
   }
 }

--- a/opencode/plugin/nono-sandbox.ts
+++ b/opencode/plugin/nono-sandbox.ts
@@ -227,24 +227,20 @@ export const NonoSandboxPlugin = async (ctx: any) => {
     // doesn't support this field yet.
     ...(caps ? { system: { inject: buildSystemContext(caps) } } : {}),
 
-    tool: {
-      execute: {
-        description: "Internal middleware hook for the nono sandbox interception layer. Do not invoke directly.",
-        // Fires after every tool call. When the result contains a denial
-        // signature we append capability context and Option A/B remediation.
-        after: async (input: unknown, result: unknown) => {
-          if (!DENIAL_PATTERN.test(JSON.stringify(result))) return result
+    "tool.execute.description": "Internal middleware hook for the nono sandbox interception layer. Do not invoke directly.",
+    // Fires after every tool call. When the result contains a denial
+    // signature we append capability context and Option A/B remediation.
+    "tool.execute.after": async (input: unknown, result: unknown) => {
+      if (!DENIAL_PATTERN.test(JSON.stringify(result))) return result
 
-          const liveCaps = readCaps()
-          if (!liveCaps) return result
+      const liveCaps = readCaps()
+      if (!liveCaps) return result
 
-          const inputText = JSON.stringify(input)
-          const resultText = JSON.stringify(result)
-          const blockedPath = extractPath(inputText) ?? extractPath(resultText)
+      const inputText = JSON.stringify(input)
+      const resultText = JSON.stringify(result)
+      const blockedPath = extractPath(inputText) ?? extractPath(resultText)
 
-          return appendGuidance(result, buildGuidance(liveCaps, blockedPath))
-        },
-      },
+      return appendGuidance(result, buildGuidance(liveCaps, blockedPath))
     },
   }
 }

--- a/opencode/skills/nono-sandbox/SKILL.md
+++ b/opencode/skills/nono-sandbox/SKILL.md
@@ -84,7 +84,7 @@ After drafting, tell the user:
 
 ## Network egress denials
 
-nono routes outbound traffic through a filtering proxy. When `network.block` is false but a host allowlist is set, only allowlisted hosts are reachable and every other connection fails — usually as a connection refused, timeout, or TLS/proxy error rather than an EPERM. `nono-status` lists the reachable hosts under "reachable hosts". Retries, alternate endpoints, proxies, or DNS changes cannot bypass the proxy; it is OS-enforced.
+nono routes outbound traffic through a filtering proxy. When `network.block` is false but a host allowlist is set, only allowlisted hosts are reachable and every other connection fails — usually as a connection refused, timeout, or TLS/proxy error rather than an EPERM. `nono_status` lists the reachable hosts under "reachable hosts". Retries, alternate endpoints, proxies, or DNS changes cannot bypass the proxy; it is OS-enforced.
 
 If a host is genuinely needed, present the same two options as for filesystem denials.
 
@@ -145,7 +145,7 @@ nono prints the session ID on start. Reattach from any terminal:
 
     nono attach <session-id>
 
-The session ID is also available inside the session as `NONO_SESSION_ID`. The installed plugin surfaces it in the `nono-status` command output.
+The session ID is also available inside the session as `NONO_SESSION_ID`. The installed plugin surfaces it in the `nono_status` tool output.
 
 To list active nono sessions:
 
@@ -162,7 +162,7 @@ Detached sessions inherit the same sandbox profile as interactive ones — the s
 - opencode state, sessions, config, and cache live under `~/.opencode`, `$XDG_CONFIG_HOME/opencode`, `$XDG_CACHE_HOME/opencode`, `$XDG_DATA_HOME/opencode`, and `$XDG_STATE_HOME/opencode`. The base profile grants all of these read/write.
 - The plugin at `$XDG_CONFIG_HOME/opencode/plugins/nono-sandbox.ts` is symlinked from the pack store. It updates automatically on `nono pull`.
 - The skill at `$XDG_CONFIG_HOME/opencode/skills/nono-sandbox/` is similarly symlinked.
-- The `nono-status` command (registered by the plugin) shows the active capability set, the network egress allowlist (reachable hosts), enabled credential routes, and the session ID for reattach.
+- The `nono_status` tool (registered by the plugin) shows the active capability set, the network egress allowlist (reachable hosts), enabled credential routes, and the session ID for reattach.
 - Do not add provider secrets to opencode's own config files. Route them through `network.credentials` in the profile instead.
 
 ## Path conventions


### PR DESCRIPTION
Fixes #8 

It still works as a hook but avoids registering `execute` tool which is:
- Not indended in this plugin
- Overrides internal opencode `execute` tool (codemode)