### PR TITLE
fix(codex): allow macOS Keychain access in sandbox profile

### DIFF
--- a/codex/package.json
+++ b/codex/package.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "name": "codex",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Teaches OpenAI Codex how to work inside a nono security sandbox.",
   "license": "Apache-2.0",
   "platforms": ["macos", "linux"],

--- a/codex/policy.json
+++ b/codex/policy.json
@@ -28,11 +28,15 @@
     "allow": [
       "$HOME/.codex",
       "$HOME/.agents",
-      "$NONO_CONFIG/profile-drafts"
+      "$NONO_CONFIG/profile-drafts",
+      { "path": "$HOME/Library/Keychains", "when": "macos" }
     ],
     "read": [
       "$NONO_PACKAGES",
       "$NONO_CONFIG/profiles"
+    ],
+    "bypass_protection": [
+      { "path": "$HOME/Library/Keychains", "when": "macos" }
     ]
   },
   "network": { "block": false },


### PR DESCRIPTION
Codex could not access the login Keychain under the nono sandbox, blocking auth flows. Mirror the claude pack handling: allow $HOME/Library/Keychains on macOS and list it under filesystem.bypass_protection.

Bump the codex pack version 0.2.0 -> 0.2.1.

Fixes #13