### PR TITLE
fix(claude): grant cc-socks so cross-session messaging works

### DIFF
--- a/antigravity/policy.json
+++ b/antigravity/policy.json
@@ -4,7 +4,7 @@
   ],
   "meta": {
     "name": "antigravity",
-    "version": "0.3.1",
+    "version": "1.0.0",
     "description": "Runtime-discovered path additions for agy",
     "author": null
   },

--- a/claude/README.md
+++ b/claude/README.md
@@ -44,6 +44,20 @@ When Claude is running inside a `nono` sandbox and a tool call fails due to bloc
 
 This prevents common bad guidance such as retrying the same action, suggesting `chmod`, or treating the failure like a normal OS permissions issue.
 
+## Sandbox Preparation
+
+The profile also has to make Claude Code's own runtime paths usable inside the sandbox.
+
+On Linux it grants `$XDG_RUNTIME_DIR/cc-socks`, the directory where Claude Code binds the
+AF_UNIX sockets it uses for cross-session messaging. Without it, sessions start with
+`Cross-session messaging is off: its socket directory could not be set up`.
+
+Landlock and Seatbelt can only attach a rule to a path that already exists, and a grant for
+a missing path is silently skipped — so `cc-socks` (tmpfs, gone after every logout) and the
+Claude state directories under `$HOME` would be dropped from the capability set on a fresh
+machine. `bin/ensure-dirs.sh` runs as a `session_hooks.before` script, on the host and
+before the sandbox boundary goes up, and creates them first.
+
 ## Included Artifacts
 
 The pack currently ships:
@@ -53,6 +67,7 @@ The pack currently ships:
 - `hooks/hooks.json`
 - `bin/nono-hook.sh`
 - `bin/nono-hook-bash.sh`
+- `bin/ensure-dirs.sh`
 
 These artifacts are declared in [`package.json`](./package.json).
 

--- a/claude/bin/ensure-dirs.sh
+++ b/claude/bin/ensure-dirs.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# nono session_hooks.before script. Runs on the host with host privileges,
+# before the sandbox goes up: Landlock can only attach a rule to a path that
+# already exists, and silently drops the grant for one that does not.
+set -euo pipefail
+
+mkdir -p \
+  "$HOME/.claude" \
+  "$HOME/.cache/claude" \
+  "$HOME/.local/state/claude/locks"
+
+# Claude Code's cross-session messaging sockets. On tmpfs, so gone after every
+# logout. An unset XDG_RUNTIME_DIR is a skip, not an error: nono leaves the
+# matching profile path unexpanded and drops that grant too.
+if [ -n "${XDG_RUNTIME_DIR:-}" ]; then
+  mkdir -m 700 -p "$XDG_RUNTIME_DIR/cc-socks"
+fi

--- a/claude/package.json
+++ b/claude/package.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
   "name": "claude",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Claude Code plugin and matching nono profile. Provides sandbox-aware diagnostics on permission failures and ships the claude-code profile via the registry.",
   "license": "Apache-2.0",
   "platforms": [
     "macos",
     "linux"
   ],
-  "min_nono_version": "0.61.0",
+  "min_nono_version": "0.63.0",
   "artifacts": [
     {
       "type": "profile",
@@ -37,6 +37,10 @@
     {
       "type": "plugin",
       "path": "bin/nono-hook-bash.sh"
+    },
+    {
+      "type": "plugin",
+      "path": "bin/ensure-dirs.sh"
     },
     {
       "type": "plugin",

--- a/claude/policy.json
+++ b/claude/policy.json
@@ -2,7 +2,7 @@
   "extends": "default",
   "meta": {
     "name": "claude",
-    "version": "1.0.0",
+    "version": "0.2.0",
     "description": "Anthropic Claude Code CLI agent (registry-managed)",
     "author": "nolabs-ai"
   },
@@ -47,10 +47,19 @@
     ],
     "bypass_protection": [
       { "path": "$HOME/Library/Keychains", "when": "macos" }
+    ],
+    "unix_socket_dir_bind": [
+      { "path": "$XDG_RUNTIME_DIR/cc-socks", "when": "linux" }
     ]
   },
   "network": { "block": false },
   "workdir": { "access": "readwrite" },
+  "session_hooks": {
+    "before": {
+      "script": "$PACK_DIR/bin/ensure-dirs.sh",
+      "timeout_secs": 10
+    }
+  },
   "open_urls": {
     "allow_origins": [
       "https://claude.ai",

--- a/claude/policy.json
+++ b/claude/policy.json
@@ -2,7 +2,7 @@
   "extends": "default",
   "meta": {
     "name": "claude",
-    "version": "0.2.0",
+    "version": "1.0.0",
     "description": "Anthropic Claude Code CLI agent (registry-managed)",
     "author": "nolabs-ai"
   },


### PR DESCRIPTION
Fixes #15 

Claude Code binds its cross-session messaging sockets in $XDG_RUNTIME_DIR/cc-socks, which the profile did not grant, so sessions started with "Cross-session messaging is off". Add a unix_socket_dir_bind entry for it, plus a session_hooks.before script that creates it (and the claude state dirs) on the host first, since Landlock drops grants for paths that do not yet exist.

Bump min_nono_version 0.61.0 -> 0.63.0: the hook is referenced as $PACK_DIR/bin/ensure-dirs.sh, and $PACK_DIR expansion in session_hooks landed in nono v0.63.0. On an older nono the path would not resolve and the hook would not run. unix_socket_dir_bind is older (v0.55.0) and does not constrain the floor. This matches opencode, which pins 0.63.0 for the same session_hooks reason.