### PR TITLE
Add omp pack, port fixes, and repo-wide namespace consistency

### DIFF
--- a/.github/workflows/pack-smoke-test.yml
+++ b/.github/workflows/pack-smoke-test.yml
@@ -117,3 +117,17 @@ jobs:
           NONO_SKIP_SANDBOX: "1"
         run: |
           bash scripts/smoke-test-pack.sh "always-further/${{ matrix.pack }}"
+
+  smoke-test-result:
+    name: Pack smoke test result
+    needs: [detect, smoke]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check smoke test outcome
+        run: |
+          if [[ "${{ needs.smoke.result }}" == "failure" || "${{ needs.smoke.result }}" == "cancelled" ]]; then
+            echo "One or more pack smoke tests failed."
+            exit 1
+          fi
+          echo "All pack smoke tests passed (or no packs changed)."

--- a/.github/workflows/pack-smoke-test.yml
+++ b/.github/workflows/pack-smoke-test.yml
@@ -13,6 +13,7 @@ on:
       - "hermes/**"
       - "openclaw/**"
       - "opencode/**"
+      - "omp/**"
       - "pi/**"
   pull_request:
     paths:
@@ -25,6 +26,7 @@ on:
       - "hermes/**"
       - "openclaw/**"
       - "opencode/**"
+      - "omp/**"
       - "pi/**"
 
 permissions:

--- a/.github/workflows/publish-omp.yml
+++ b/.github/workflows/publish-omp.yml
@@ -1,0 +1,51 @@
+name: Publish omp pack
+on:
+  push:
+    tags: ["omp-v*"]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Read version from package.json
+        id: version
+        run: |
+          set -euo pipefail
+          VERSION=$(jq -r '.version' omp/package.json)
+          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+            echo "ERROR: omp/package.json is missing a 'version' field"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Build files list from package.json
+        id: files
+        run: |
+          set -euo pipefail
+          {
+            echo "package.json"
+            [ -f "omp/README.md" ] && echo "README.md"
+            jq -r '.artifacts[].path' "omp/package.json"
+          } | sort -u > /tmp/files.txt
+          {
+            echo "files<<EOF"
+            cat /tmp/files.txt
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: nolabs-ai/agent-sign@c9426f1a00f823dd53e7b9068d910a68b43e49e9 # v0.0.11
+        with:
+          publish: "true"
+          package-name: omp
+          package-namespace: nolabs-ai
+          package-version: ${{ steps.version.outputs.version }}
+          package-path: omp
+          registry-url: https://registry.nono.sh/api/v1
+          files: ${{ steps.files.outputs.files }}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Current packs in this repository include:
 - [`claude-autoresearch`](./claude-autoresearch): GPU-enabled profile and plugin for running [autoresearch](https://github.com/Kexin-xu-01/autoresearch-nono) autonomous ML loops inside the `nono` sandbox — A100/CUDA workloads with kernel-level enforcement inherited by training subprocesses
 - [`codex`](./codex): Codex integration for working inside the `nono` sandbox
 - [`goose`](./goose): Goose CLI profile and Open Plugin for working inside the `nono` sandbox
+- [`omp`](./omp): Oh My Pi coding harness plugin and profile for working inside the `nono` sandbox
 - [`pi`](./pi): Pi Coding Agent package and profile for working inside the `nono` sandbox
 
 Typical pack contents:

--- a/antigravity/README.md
+++ b/antigravity/README.md
@@ -84,7 +84,7 @@ The pack ships `policy.json`, the `nono` profile for `agy` (installed as
 `antigravity`, alias `agy`). Launch a sandboxed session with:
 
 ```bash
-nono run --profile antigravity -- agy
+nono run --profile nolabs-ai/antigravity -- agy
 ```
 
 The profile is captured from runtime-discovered `agy` access (config under

--- a/claude/README.md
+++ b/claude/README.md
@@ -8,6 +8,16 @@
 
 It installs a Claude plugin, hook definitions, shell helpers, and a packaged skill that make Claude Code behave correctly when it is running inside a `nono` security sandbox.
 
+## Quick start
+
+```bash
+# Install the pack
+nono pull nolabs-ai/claude
+
+# Run Claude Code inside the sandbox
+nono run --profile nolabs-ai/claude -- claude
+```
+
 ## What It Does
 
 This pack is focused on one problem: when Claude hits a sandbox boundary, it should stop guessing and explain the real fix.

--- a/codex/README.md
+++ b/codex/README.md
@@ -9,14 +9,14 @@ Sandbox profile and Codex plugin for running [OpenAI Codex CLI](https://develope
 Install:
 
 ```
-nono run --profile codex -- codex
+nono run --profile nolabs-ai/codex -- codex
 ```
 
 If the pack isn't already installed, nono will prompt to pull it.
 
 ## What's in the pack
 
-- **`policy.json`** — sandbox profile (loaded as `--profile codex`). Grants `~/.codex`, `~/.agents`, `~/.config/nono/{profiles,packages}` (read-only), the OpenAI auth origin, and runtime groups for Node, Rust, Python, Nix.
+- **`policy.json`** — sandbox profile (loaded as `--profile nolabs-ai/codex`). Grants `~/.codex`, `~/.agents`, `~/.config/nono/{profiles,packages}` (read-only), the OpenAI auth origin, and runtime groups for Node, Rust, Python, Nix.
 - **`.codex-plugin/plugin.json`** — Codex plugin manifest, exposes the `nono-sandbox` skill.
 - **`bin/nono-hook.sh`** — compatibility no-op for older installs that still have the previous `PostToolUse` hook entry.
 - **`bin/nono-hook-session.sh`** — compatibility no-op for older installs that still have the previous `SessionStart` hook entry.

--- a/copilot-cli/README.md
+++ b/copilot-cli/README.md
@@ -10,7 +10,7 @@
 - Include read-only access to `~/.config/gh`
 - Block all other filesystem paths at the kernel level
 
-The pack ships three profiles: a shared base (`copilot-cli-base`) and two authentication-specific profiles that extend it:
+The pack ships three profiles: a shared base (`nolabs-ai/copilot-base`) and two authentication-specific profiles that extend it:
 
 | Profile | Auth method | Best for |
 |---|---|---|
@@ -31,7 +31,7 @@ Follow the prompts to authenticate with GitHub. The profile reads `~/.config/gh`
 **Step 2 — Run**
 
 ```bash
-nono run --profile copilot-cli -- copilot
+nono run --profile nolabs-ai/copilot-cli -- copilot
 ```
 
 ---
@@ -59,7 +59,7 @@ Omitting the value from the command line causes `security` to prompt for it inte
 **Step 3 — Run**
 
 ```bash
-nono run --profile copilot-cli-proxy -- copilot
+nono run --profile nolabs-ai/copilot-cli-proxy -- copilot
 ```
 ---
 
@@ -69,13 +69,13 @@ nono run --profile copilot-cli-proxy -- copilot
 nono pull nolabs-ai/copilot-cli
 ```
 
-All three profiles are installed automatically. Use `--profile copilot-cli` or `--profile copilot-cli-proxy` to select one at runtime. `copilot-cli-base` can be used directly but has no auth configuration, so it would requires manual login.
+All three profiles are installed automatically. Use `--profile nolabs-ai/copilot-cli` or `--profile nolabs-ai/copilot-cli-proxy` to select one at runtime. `nolabs-ai/copilot-base` can be used directly but has no auth configuration, so it would requires manual login.
 
 ## Included Artifacts
 
 | Artifact | Type | Purpose |
 |---|---|---|
-| `profiles/copilot-base.json` | profile | Shared base profile (`copilot-cli-base`) — extended by both auth profiles |
+| `profiles/copilot-base.json` | profile | Shared base profile (`nolabs-ai/copilot-base`) — extended by both auth profiles |
 | `profiles/copilot-gh.json` | profile | Sandbox profile using `gh` auth (`copilot-cli`) |
 | `profiles/copilot-proxy.json` | profile | Sandbox profile using credential injection (`copilot-cli-proxy`) |
 | `skills/copilot-sandbox/SKILL.md` | instruction | Teaches the agent its sandbox constraints |

--- a/goose/README.md
+++ b/goose/README.md
@@ -12,7 +12,7 @@ If the pack is not already installed, nono will prompt to pull it.
 
 ## What's in the pack
 
-- **`policy.json`** - sandbox profile loaded as `--profile goose`. Grants Goose config/cache/state, `~/.agents` for plugins and skills, standard Node/Rust/Python/Nix runtime groups, common provider auth origins, and read access to nono packages/profiles.
+- **`policy.json`** - sandbox profile loaded as `--profile nolabs-ai/goose`. Grants Goose config/cache/state, `~/.agents` for plugins and skills, standard Node/Rust/Python/Nix runtime groups, common provider auth origins, and read access to nono packages/profiles.
 - **`plugin.json`** - Goose Open Plugin manifest. Goose discovers this pack from `~/.agents/plugins/nono`.
 - **`hooks/hooks.json`** - Goose hook wiring for shell and tool-failure diagnostics.
 - **`bin/nono-hook.sh`** - hook command that detects likely sandbox-denial output and prints nono-specific remediation guidance.

--- a/hermes/README.md
+++ b/hermes/README.md
@@ -39,7 +39,7 @@ nono profile init hermes --extends nolabs-ai/hermes --full
 **Step 3 — run Hermes:**
 
 ```bash
-nono run --profile hermes --allow-cwd -- hermes
+nono run --profile nolabs-ai/hermes --allow-cwd -- hermes
 ```
 
 A custom profile is also where you add credential routes, extra filesystem grants, and any other customizations — see the sections below.
@@ -253,7 +253,7 @@ For tighter control you can add `endpoint_rules` — a list of `{"method", "path
 Run Hermes with your child profile:
 
 ```bash
-nono run --profile hermes -- hermes
+nono run --profile nolabs-ai/hermes -- hermes
 ```
 
 ## Audit Logging
@@ -273,13 +273,13 @@ nono audit cleanup                       # remove old sessions
 To disable audit logging for a session, pass `--no-audit`:
 
 ```bash
-nono run --profile hermes --no-audit -- hermes
+nono run --profile nolabs-ai/hermes --no-audit -- hermes
 ```
 
 If you want the session log but don't need tamper-evident protection:
 
 ```bash
-nono run --profile hermes --no-audit-integrity -- hermes
+nono run --profile nolabs-ai/hermes --no-audit-integrity -- hermes
 ```
 
 If you add secrets-adjacent flags to your Hermes invocation, you can extend nono's redaction rules so they never appear in the log. Add to `~/.config/nono/config.toml`:
@@ -296,7 +296,7 @@ extra_query_keys = ["sig", "signature"]
 nono can snapshot the filesystem before Hermes runs and let you selectively restore any files it changed or deleted. This is useful when you want to review or undo an agent session without having to figure out what changed by hand.
 
 ```bash
-nono run --rollback --profile hermes  -- hermes
+nono run --rollback --profile nolabs-ai/hermes  -- hermes
 ```
 
 With `--rollback` active, nono takes a baseline snapshot before execution and a final snapshot after. When Hermes exits, if any files were modified or deleted you get an interactive review showing a per-file diff and a prompt to restore whichever files you want back.
@@ -315,7 +315,7 @@ nono rollback cleanup --older-than 7      # remove sessions older than 7 days
 To suppress the interactive review prompt (for scripting):
 
 ```bash
-nono run --rollback --no-rollback-prompt --profile hermes -- hermes
+nono run --rollback --no-rollback-prompt --profile nolabs-ai/hermes -- hermes
 ```
 
 Exclude noisy paths from snapshot tracking in your child profile:
@@ -334,7 +334,7 @@ Exclude noisy paths from snapshot tracking in your child profile:
 By default, nono runs Hermes as a child process. This means if you stop the nono session, you also stop Hermes and any subprocesses it spawned. If you want Hermes to keep running after you exit nono, use `--detached`:
 
 ```bash
-nono run --profile hermes --detached -- hermes
+nono run --profile nolabs-ai/hermes --detached -- hermes
 ```
 
 You can now attach to the running session later to review logs, check status, or run `nono why` queries:

--- a/omp/README.md
+++ b/omp/README.md
@@ -1,6 +1,6 @@
 # omp
 
-Oh My Pi coding harness plugin and matching nono profile for working inside the [nono](https://nono.sh) security sandbox.
+`omp` is a nono package for [Oh My Pi](https://github.com/can1357/oh-my-pi) (OMP), the pi-coding-agent fork. It provides a secure sandbox for running OMP and any tools it invokes, with built-in protections for your API keys, system credentials, and filesystem. Use it to safely run OMP on your machine and sleep a little easier knowing that even if OMP or a tool it runs goes rogue, your secrets and system are protected by nono's multi-layered security model.
 
 ## What this pack provides
 
@@ -8,15 +8,47 @@ Oh My Pi coding harness plugin and matching nono profile for working inside the 
 - **Sandbox awareness extension** — hooks into OMP's event system to detect permission denials and inject diagnostic guidance
 - **Sandbox skill** — detailed diagnosis and remediation documentation reachable via `skill://nono-sandbox`
 
-## Quick start
+## Install
+
+Pull the package first, then create a custom profile before running. This avoids the interactive grants prompt that appears when nono encounters paths the base profile doesn't cover:
+
+**Step 1 — pull the package:**
 
 ```bash
-# Install the pack
-nono pack install omp
-
-# Run OMP inside the sandbox
-nono run --profile omp -- omp
+nono pull nolabs-ai/omp
 ```
+
+**Step 2 — create a custom profile:**
+
+```bash
+nono profile init omp --extends nolabs-ai/omp --full
+```
+
+A custom profile is also where you add credential routes, API keys, tokens, extra filesystem grants, and any other customizations — see the sections below. It's worth running this step, even if you don't think you'll need any custom grants or credentials, just to avoid the grants prompt later.
+
+```bash
+nono run --profile omp --allow-cwd -- omp
+```
+
+### First-run grants prompt
+
+If you run nono before creating a custom profile, nono may detect paths that OMP needs but that the base profile doesn't cover — your shell config, a tool on a non-standard path, etc. When this happens you'll see a prompt like:
+
+```
+Sandbox denial: 3 paths blocked.
+  ~/.config/gh (read)
+  ~/dev/dotfiles/zsh (read)
+  /usr/local/sbin (read)
+
+[nono] Choose suppress to keep denying all listed paths and stop future save suggestions.
+Save suggestions to a user profile? [g] grant / [s] suppress / [Enter] skip:
+```
+
+- **`g` (grant)** — saves the extra path grants to a user profile. Use the same name you plan to use for your custom profile (e.g. `omp`) so both sets of grants live in one place.
+- **`s` (suppress)** — stops nono from suggesting these paths in future. The paths remain denied.
+- **Enter (skip)** — skips saving for now. You'll be prompted again next time.
+
+The cleanest approach is to skip (`Enter`) and add any extra paths manually to your child profile's `filesystem.read` or `filesystem.allow` block.
 
 ## What the profile grants
 
@@ -25,9 +57,18 @@ nono run --profile omp -- omp
 | `~/.omp/` | read/write | OMP config, sessions, plugins, logs, extensions, skills |
 | `$NONO_CONFIG/profile-drafts/` | read/write | User-authored profile extensions |
 | `$NONO_PACKAGES`, `$NONO_CONFIG/profiles` | read | Registry-managed pack files |
+| `~/.agents/skills`, `~/.codex/skills`, `~/.config/opencode/skills`, `~/.claude/plugins/cache` | read | OMP's cross-agent skill discovery |
+| `~/.codex/config.toml`, `~/.claude/settings.json`, `~/.claude/plugins/installed_plugins.json`, `~/.claude.json` | read | OMP's session-import features (`--from-claude`, `--from-codex`) probe these on startup |
+| `~/Library/Spelling` (macOS) | read | macOS's native spellchecker, used by OMP's TUI text input |
 | Network | all outbound | Provider APIs, MCP servers, package registries |
 
-The profile is intentionally minimal — no credential routes, no provider-specific URL allowlists. Extend with `"extends": "omp"` in a profile draft for tighter controls.
+The profile is intentionally minimal beyond that — no credential routes are enabled by default. Extend with `"extends": "nolabs-ai/omp"` in a profile draft for tighter controls.
+
+## Custom profiles
+
+To create your own custom profile that extends the base `nolabs-ai/omp` profile, use the `nono profile init` command with the `--extends` flag. This allows you to inherit from the base profile while customizing specific aspects such as credential routes and network filtering.
+
+Hopefully you already have a `~/.config/nono/profile/omp.json` file from the earlier step (if not go back and run `nono profile init`); you can now edit that file to add credential routes, API keys, tokens, extra filesystem grants, and any other customizations — see the sections below. When you're happy with the profile, create a repo, push the code and add it to this registry — you can then pull your custom profile from any machine (`nono pull johndoe/<your-profile>`) and run OMP just how you like with the same profile and settings everywhere.
 
 ## Sandbox awareness
 
@@ -53,13 +94,222 @@ To disable it, edit the installed profile (`~/.config/nono/profiles/omp.json`, o
 
 Denial detection and system-prompt context injection remain active either way; only the status entry is suppressed.
 
+## Credential Protection
+
+nono protects API keys using a **phantom credential** model. Rather than passing your real key into the sandbox, nono generates a short-lived random token and injects that into OMP instead. When OMP makes an outbound API call carrying the phantom token, nono's proxy intercepts the request, validates the token, fetches the real key from your system keystore (macOS Keychain, Linux Secret Service, 1Password, etc.), and swaps it in before the request leaves the machine. The real key is never visible to the sandboxed process, so even if OMP or a tool it runs were compromised, an attacker would obtain only the useless phantom — not the credential itself.
+
+> **Do not store API keys in `~/.omp`.** OMP's own credential store (`~/.omp/agent/agent.db`) is inside the sandbox because OMP must read it; a real key there is visible to the sandboxed process and bypasses nono's phantom credential protection. Keep keys in nono's keychain (or a URI ref source) and let nono inject them.
+
+### Built-in providers
+
+The base `omp` profile does not enable provider credentials by default. This avoids warnings for unused providers from becoming part of the session boundary.
+
+The following providers are built in and ready to use. How you store the key depends on the route — some read from the system keychain, others read from an environment variable in nono's own process:
+
+| Route Name  | Provider   | Storage method | Key name / account  |
+|-------------|------------|-----------------|----------------------|
+| `openai`    | OpenAI     | nono keychain   | `OPENAI_API_KEY`    |
+| `anthropic` | Anthropic  | nono keychain   | `ANTHROPIC_API_KEY` |
+| `gemini`    | Gemini     | nono keychain   | `GOOGLE_API_KEY`    |
+| `opencode`  | opencode   | nono keychain   | `OPENCODE_API_KEY`  |
+| `github`    | GitHub     | nono keychain   | `GITHUB_TOKEN`      |
+| `gitlab`    | GitLab     | nono keychain   | `GITLAB_TOKEN`      |
+
+Store each key in the nono keychain service using the exact account name shown in the table above. Then add the route name to the `credentials` array in your child profile's `network` block to activate it:
+
+```json
+  "network": {
+    "block": false,
+    "allow_domain": [],
+    "credentials": ["opencode"],
+    "open_port": [],
+    "listen_port": [],
+    "custom_credentials": {}
+  },
+```
+
+The proxy will handle the rest — when OMP makes a request to an API endpoint matching the route, nono swaps in the real key from the keychain before forwarding the request upstream.
+
+You can enable multiple providers at once:
+
+```json
+"credentials": ["anthropic", "opencode"]
+```
+
+If you want to use a provider that isn't in the built-in list, add it with `custom_credentials` — see the [Custom providers](#custom-providers) section below for field details and examples.
+
+#### Step 1 — store the key
+
+**For keychain-backed routes** (`openai`, `anthropic`, `gemini`, `opencode`, `github`, `gitlab`):
+
+##### macOS Keychain:
+
+You can add the key with `security` or the Keychain UI. The `-a` flag sets the account name, which is how nono looks up the key at runtime. The `-s` flag sets the service, which nono uses to group related credentials together in the UI.
+
+```bash
+security add-generic-password -U -s "nono" -a "OPENAI_API_KEY" -w
+security add-generic-password -U -s "nono" -a "ANTHROPIC_API_KEY" -w
+security add-generic-password -U -s "nono" -a "GOOGLE_API_KEY" -w
+security add-generic-password -U -s "nono" -a "OPENCODE_API_KEY" -w
+security add-generic-password -U -s "nono" -a "GITHUB_TOKEN" -w
+security add-generic-password -U -s "nono" -a "GITLAB_TOKEN" -w
+```
+
+Keep `-w` last so macOS prompts for the value instead of recording it in shell history.
+
+##### Linux Secret Service:
+
+```bash
+secret-tool store --label="nono: OPENCODE_API_KEY" \
+  service nono username OPENCODE_API_KEY target default
+```
+
+On Linux this requires a running Secret Service provider such as GNOME Keyring or KWallet. In SSH-only or headless environments, check the nono credential docs before choosing a storage backend.
+
+###### Alternative storage methods
+
+If your keys live in 1Password, a file, or an environment variable, you can override any built-in route using `custom_credentials` — see the [Custom providers](#custom-providers) section below for field details and examples.
+
+For the full credential URI ref model (`op://`, `apple-password://`, `file://`, `env://`), see:
+
+- https://nono.sh/docs/cli/features/credential-injection
+
+#### Step 2 — run OMP with the child profile
+
+```bash
+nono run --profile omp -- omp
+```
+
+### Custom providers
+
+If the provider you need isn't in the built-in list, you can add it with `custom_credentials`. The same phantom-token swap mechanism applies — you define the upstream URL, the keychain account to use, and optionally which API endpoints are permitted.
+
+This example adds [OpenRouter](https://openrouter.ai) — an OpenAI-compatible model-routing API that authenticates with `Authorization: Bearer <key>`.
+
+Store the key in your system keyring under the account name you'll reference in the profile (`OPENROUTER_API_KEY` here):
+
+```bash
+security add-generic-password -U -s "nono" -a "OPENROUTER_API_KEY" -w
+```
+
+Then open your child profile and update the `network` block:
+
+```json
+"network": {
+  "block": false,
+  "allow_domain": [],
+  "credentials": ["openrouter"],
+  "open_port": [],
+  "listen_port": [],
+  "custom_credentials": {
+    "openrouter": {
+      "upstream": "https://openrouter.ai/api/v1",
+      "credential_key": "OPENROUTER_API_KEY",
+      "env_var": "OPENROUTER_API_KEY"
+    }
+  }
+}
+```
+
+The map key (`"openrouter"`) is the route name. **It must also appear in the `credentials` array** — nono only activates routes explicitly listed there. `inject_header` and `credential_format` are omitted because the defaults (`"Authorization"` and `"Bearer {}"`) already match what OpenRouter expects.
+
+For tighter control you can add `endpoint_rules` — a list of `{"method", "path"}` pairs that act as an L7 allow-list. When non-empty, the proxy rejects any request that doesn't match, even with a valid phantom token. Omit it, as above, to allow all paths under the route.
+
+Run OMP with your child profile:
+
+```bash
+nono run --profile omp -- omp
+```
+
+## Audit Logging
+
+Every nono session produces an append-only audit log recording what OMP did: the command and arguments (with secrets redacted), start/end timestamps, exit code, capability decisions, network events, and the filesystem paths it touched. Logs are written to `~/.nono/audit/` as `session.json` and `audit-events.ndjson`, and are tamper-evident by default.
+
+```bash
+nono audit list                          # all sessions
+nono audit list --today                  # today only
+nono audit list --command omp            # filter by command
+nono audit show <session-id>             # inspect a session
+nono audit show <session-id> --json      # machine-readable
+nono audit verify <session-id>           # verify log integrity
+nono audit cleanup                       # remove old sessions
+```
+
+To disable audit logging for a session, pass `--no-audit`:
+
+```bash
+nono run --profile omp --no-audit -- omp
+```
+
+If you want the session log but don't need tamper-evident protection:
+
+```bash
+nono run --profile omp --no-audit-integrity -- omp
+```
+
+## Rollbacks
+
+nono can snapshot the filesystem before OMP runs and let you selectively restore any files it changed or deleted:
+
+```bash
+nono run --rollback --profile omp -- omp
+```
+
+With `--rollback` active, nono takes a baseline snapshot before execution and a final snapshot after. When OMP exits, if any files were modified or deleted you get an interactive review showing a per-file diff and a prompt to restore whichever files you want back. Snapshots are stored in `~/.nono/rollbacks/<session-id>/` using SHA-256 content-addressable storage with Merkle tree verification.
+
+```bash
+nono rollback list                        # past sessions grouped by project
+nono rollback show <id> --diff            # inspect what changed
+nono rollback restore <id>                # interactive restore
+nono rollback restore <id> --dry-run      # preview without writing
+nono rollback verify <id>                 # check Merkle integrity
+nono rollback cleanup --older-than 7      # remove sessions older than 7 days
+```
+
+To suppress the interactive review prompt (for scripting):
+
+```bash
+nono run --rollback --no-rollback-prompt --profile omp -- omp
+```
+
+Exclude noisy paths from snapshot tracking in your child profile:
+
+```json
+"undo": {
+  "exclude_patterns": ["node_modules", ".next", "__pycache__", ".omp"],
+  "exclude_globs": ["*.tmp.[0-9]*.[0-9]*"]
+}
+```
+
+`.gitignore` entries in the working directory are also respected automatically.
+
+## Run detached
+
+By default, nono runs OMP as a child process. This means if you quit OMP, any subprocesses it spawned will also be terminated. If you want OMP to keep running after you exit nono, use `--detached`:
+
+```bash
+nono run --profile omp --detached -- omp
+```
+
+You can now attach to the running session later to review logs, check status, or run `nono why` queries:
+
+```bash
+nono attach <session-id>
+```
+
+To view details of all running sessions:
+
+```bash
+nono ps
+```
+
 ## Extending the profile
 
 Create a profile draft to add grants:
 
 ```json
 {
-  "extends": "omp",
+  "extends": "nolabs-ai/omp",
   "meta": { "name": "omp-extra", "version": "1.0.0" },
   "filesystem": {
     "read": ["/path/to/data"]
@@ -76,6 +326,31 @@ Then promote it outside the sandbox:
 nono profile validate --draft omp-extra
 nono profile promote omp-extra
 nono run --profile omp-extra -- omp
+```
+
+## nono inbuilt helper commands
+
+The plugin exposes `/nono-status` inside OMP's TUI once the extension loads.
+
+Inside a running OMP sandbox, use `nono why --self` so the query uses the sandbox context for any particular file or network access check:
+
+```bash
+nono why --self --path /path/to/some/file --op read
+```
+
+### Agent Profile Expansion and Promotion
+
+When a sandbox denial occurs, the agent can draft profile changes, but it cannot directly edit active profiles under `~/.config/nono/profiles`. This keeps policy changes behind an explicit user promotion step. When the agent drafts a profile change, it writes the proposed profile to `~/.config/nono/profile-drafts/<name>.json`. Review the draft, then promote it to make it active:
+
+```bash
+nono profile validate --draft omp-agent
+nono profile promote omp-agent
+```
+
+## Uninstalling
+
+```bash
+nono remove nolabs-ai/omp
 ```
 
 ## License

--- a/omp/policy.json
+++ b/omp/policy.json
@@ -4,7 +4,7 @@
     "name": "omp",
     "version": "1.0.0",
     "description": "Oh My Pi coding harness (registry-managed)",
-    "author": "rlex"
+    "author": "nolabs-ai, rlex, koalajoe23"
   },
   "groups": {
     "include": [
@@ -37,18 +37,19 @@
       "$HOME/.local/share/mise/installs/github-can1357-oh-my-pi/latest/omp",
       "$HOME/.local/bin/omp",
       "$HOME/.agents/skills",
+      "$HOME/.nvm",
+      { "path": "$HOME/Library/Spelling", "when": "macos" },
       "$HOME/.codex/skills",
       "$HOME/.config/opencode/skills",
       "$HOME/.claude/plugins/cache",
       "$HOME/.codex/config.toml",
       "$HOME/.claude/settings.json",
       "$HOME/.claude/plugins/installed_plugins.json",
-      "$HOME/.claude/plugins/cache",
       "$HOME/.claude.json",
       "$HOME/.CFUserTextEncoding"
     ],
     "suppress_save_prompt": [
-      "$NONO_PACKAGES/always-further/omp"
+      "$NONO_PACKAGES/nolabs-ai/omp"
     ]
   },
   "network": {
@@ -77,7 +78,14 @@
         "credential_key": "GOOGLE_API_KEY",
         "inject_header": "x-goog-api-key",
         "credential_format": "{}",
-        "env_var": "GOOGLE_API_KEY"
+        "env_var": "GEMINI_API_KEY"
+      },
+      "opencode": {
+        "upstream": "https://opencode.ai/zen/v1",
+        "credential_key": "OPENCODE_API_KEY",
+        "inject_header": "Authorization",
+        "credential_format": "Bearer {}",
+        "env_var": "OPENCODE_API_KEY"
       },
       "github": {
         "upstream": "https://api.github.com",
@@ -99,7 +107,12 @@
     "access": "readwrite"
   },
   "open_urls": {
-    "allow_origins": [],
+    "allow_origins": [
+      "https://auth.openai.com",
+      "https://claude.ai",
+      "https://github.com",
+      "https://opencode.ai"
+    ],
     "allow_localhost": true
   },
   "allow_launch_services": true,
@@ -113,7 +126,8 @@
       "node_modules",
       ".next",
       "__pycache__",
-      "target"
+      "target",
+      ".omp"
     ],
     "exclude_globs": ["*.tmp.[0-9]*.[0-9]*"]
   },

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -35,13 +35,13 @@ nono pull nolabs-ai/openclaw
 **Single agent**
 
 ```bash
-nono run --profile openclaw -- openclaw
+nono run --profile nolabs-ai/openclaw -- openclaw
 ```
 
 **Named agent instance**
 
 ```bash
-nono run --profile openclaw --home ~/.openclaw-agent1 -- openclaw
+nono run --profile nolabs-ai/openclaw --home ~/.openclaw-agent1 -- openclaw
 ```
 
 ## Included Artifacts

--- a/opencode/README.md
+++ b/opencode/README.md
@@ -56,7 +56,7 @@ Store the corresponding secret in the nono keychain under the env-var-shaped acc
 Run opencode in a detached session that survives terminal disconnects:
 
 ```bash
-nono run --profile opencode --detach -- opencode
+nono run --profile nolabs-ai/opencode --detach -- opencode
 ```
 
 Reattach from any terminal:
@@ -76,7 +76,7 @@ nono pull nolabs-ai/opencode
 Or let nono prompt you on first use:
 
 ```bash
-nono run --profile opencode -- opencode
+nono run --profile nolabs-ai/opencode -- opencode
 ```
 
 ## Activation

--- a/pi/README.md
+++ b/pi/README.md
@@ -24,7 +24,7 @@ nono profile init pi --extends nolabs-ai/pi --full
 A custom profile is also where you add credential routes, API keys, tokens, extra filesystem grants, and any other customizations — see the sections below. Its worth running this step, even if you don't think you'll need any custom grants or credentials, just to avoid the grants prompt later. 
 
 ```bash
-nono run --profile pi --allow-cwd -- pi
+nono run --profile nolabs-ai/pi --allow-cwd -- pi
 ```
 
 ### First-run grants prompt
@@ -139,7 +139,7 @@ For the full credential URI ref model (`op://`, `apple-password://`, `file://`, 
 Then run pi with your child profile:
 
 ```bash
-nono run --profile pi -- pi
+nono run --profile nolabs-ai/pi -- pi
 ```
 
 ### Custom providers
@@ -218,7 +218,7 @@ For tighter control you can add `endpoint_rules` — a list of `{"method", "path
 Run pi with your child profile:
 
 ```bash
-nono run --profile pi -- pi
+nono run --profile nolabs-ai/pi -- pi
 ```
 
 ## Audit Logging
@@ -238,13 +238,13 @@ nono audit cleanup                       # remove old sessions
 To disable audit logging for a session, pass `--no-audit`:
 
 ```bash
-nono run --profile pi --no-audit -- pi
+nono run --profile nolabs-ai/pi --no-audit -- pi
 ```
 
 If you want the session log but don't need tamper-evident protection:
 
 ```bash
-nono run --profile pi --no-audit-integrity -- pi
+nono run --profile nolabs-ai/pi --no-audit-integrity -- pi
 ```
 
 If you add secrets-adjacent flags to your pi invocation, you can extend nono's redaction rules so they never appear in the log. Add to `~/.config/nono/config.toml`:
@@ -261,7 +261,7 @@ extra_query_keys = ["sig", "signature"]
 nono can snapshot the filesystem before pi runs and let you selectively restore any files it changed or deleted. This is useful when you want to review or undo an agent session without having to figure out what changed by hand.
 
 ```bash
-nono run --rollback --profile pi  -- pi
+nono run --rollback --profile nolabs-ai/pi  -- pi
 ```
 
 With `--rollback` active, nono takes a baseline snapshot before execution and a final snapshot after. When pi exits, if any files were modified or deleted you get an interactive review showing a per-file diff and a prompt to restore whichever files you want back.
@@ -280,7 +280,7 @@ nono rollback cleanup --older-than 7      # remove sessions older than 7 days
 To suppress the interactive review prompt (for scripting):
 
 ```bash
-nono run --rollback --no-rollback-prompt --profile pi -- pi
+nono run --rollback --no-rollback-prompt --profile nolabs-ai/pi -- pi
 ```
 
 Exclude noisy paths from snapshot tracking in your child profile:
@@ -301,7 +301,7 @@ nono comes with a built-in PTY multiplexer, so you can detach and re-attach to s
 By default, nono runs pi as a child process. This means if you quit pi, any subprocesses it spawned will also be terminated. If you want pi to keep running, but not have it as an active terminal session, use `--detached`:
 
 ```bash
-nono run --profile pi --detached -- pi
+nono run --profile nolabs-ai/pi --detached -- pi
 ```
 
 You can now attach to the running session later to review logs, check status, or run `nono why` queries:


### PR DESCRIPTION
- Bring the omp (Oh My Pi) pack to release parity with the pi pack: fix policy.jsons stale always-further namespace, wrong author credit, gemini/opencode credential routes, OAuth allow_origins, .omp rollback exclude, and add the macOS Spelling read grant (all verified live via scripts/dev-install.sh + nono run)
- Add publish-omp.yml release workflow and wire omp/** into pack-smoke-test.yml and the root READMEs pack listing
- Rewrite omp/README.md to match pi/README.mds documentation depth (Install, Credential Protection, Audit Logging, Rollbacks, Run detached, helper commands)
- Fix copilot-cli/README.mds copilot-cli-base -> copilot-base naming mismatch against its actual install_as
- Add a missing Quick start section to claude/README.md
- Fully qualify every --profile reference across all pack READMEs to nolabs-ai/<pack>, consistent with existing pull/remove examples