### PR TITLE
Fix codex pack staleness and dev-install.sh toml_block marker mismatch

### DIFF
--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Teaches OpenAI Codex how to work inside a nono security sandbox.",
   "author": {
-    "name": "Always Further",
+    "name": "nolabs-ai",
     "url": "https://github.com/nolabs-ai"
   },
   "homepage": "https://nono.sh",

--- a/codex/README.md
+++ b/codex/README.md
@@ -22,9 +22,9 @@ If the pack isn't already installed, nono will prompt to pull it.
 - **`bin/nono-hook-session.sh`** — compatibility no-op for older installs that still have the previous `SessionStart` hook entry.
 - **`skills/nono-sandbox/SKILL.md`** — skill describing how to diagnose and resolve sandbox denials.
 
-## Activating the hooks
+## Activating sandbox guidance
 
-`nono pull nolabs-ai/codex` writes the marketplace registration, the hook entries, and the cache symlink, but leaves your `config.toml` alone — that file often contains user customisations and a clean TOML merge isn't worth the risk of clobbering them. After accepting the install prompt you'll see a one-line reminder if the flag isn't set.
+`nono pull nolabs-ai/codex` writes the marketplace registration and the cache symlink, and merges a marked `nono` block into `~/.codex/config.toml` (`developer_instructions`, plus the marketplace/plugin entries) so Codex knows how to diagnose and remediate nono sandbox denials. The merge is scoped to a marked block, so your other `config.toml` settings are left untouched.
 
 ## Hook noise
 

--- a/scripts/dev-install.sh
+++ b/scripts/dev-install.sh
@@ -370,8 +370,8 @@ marker_id     = sys.argv[2]
 block_content = sys.argv[3]
 position      = sys.argv[4]
 
-begin_marker = f'# BEGIN nono-pack:{marker_id}'
-end_marker   = f'# END nono-pack:{marker_id}'
+begin_marker = f'# >>> nono:{marker_id} >>>'
+end_marker   = f'# <<< nono:{marker_id} <<<'
 
 try:
     with open(target_path) as f:
@@ -425,8 +425,8 @@ import sys
 target_path = sys.argv[1]
 marker_id   = sys.argv[2]
 
-begin_marker = f'# BEGIN nono-pack:{marker_id}'
-end_marker   = f'# END nono-pack:{marker_id}'
+begin_marker = f'# >>> nono:{marker_id} >>>'
+end_marker   = f'# <<< nono:{marker_id} <<<'
 
 with open(target_path) as f:
     lines = f.readlines()


### PR DESCRIPTION
- Update dev-install.sh toml_block marker format to match nonos actual convention (>>> nono:<id> >>> / <<< nono:<id> <<<), fixing a bug where local dev installs would duplicate the codex pack config.toml block instead of updating it in place
- Fix codex/.codex-plugin/plugin.json stale Always Further author to nolabs-ai
- Rewrite codex/README.md Activating the hooks section, which incorrectly claimed nono pull leaves config.toml untouched and writes hook entries that no longer exist