### PR TITLE
fix: add --self flag to nono why in sandbox diagnostics

### DIFF
--- a/.github/workflows/pack-smoke-test.yml
+++ b/.github/workflows/pack-smoke-test.yml
@@ -112,7 +112,27 @@ jobs:
       - name: Install pack into nono store
         run: |
           set -euo pipefail
-          bash scripts/install-pack-local.sh "${{ matrix.pack }}"
+
+          # A pack's profile can `extend` another pack's profile by fully
+          # qualified name (e.g. "nolabs-ai/claude"). Install that base pack
+          # first so inheritance resolves — the matrix only installs the one
+          # changed pack otherwise, which leaves cross-pack extends dangling.
+          PACK="${{ matrix.pack }}"
+          PROFILE_PATH=$(jq -r '.artifacts[] | select(.type=="profile") | .path' "$PACK/package.json" | head -1)
+          if [[ -n "$PROFILE_PATH" && -f "$PACK/$PROFILE_PATH" ]]; then
+            EXTENDS=$(jq -r '.extends | if type=="array" then .[] else . end' "$PACK/$PROFILE_PATH" 2>/dev/null || true)
+            while IFS= read -r ext; do
+              [[ -z "$ext" || "$ext" != */* ]] && continue
+              DEP_NS="${ext%%/*}"
+              DEP_PACK="${ext#*/}"
+              if [[ -d "$DEP_PACK" && -f "$DEP_PACK/package.json" ]]; then
+                echo "Installing dependency: $ext"
+                bash scripts/install-pack-local.sh "$DEP_PACK" "$DEP_NS"
+              fi
+            done <<< "$EXTENDS"
+          fi
+
+          bash scripts/install-pack-local.sh "$PACK"
 
       - name: Run smoke tests
         env:

--- a/antigravity/skills/nono-sandbox/SKILL.md
+++ b/antigravity/skills/nono-sandbox/SKILL.md
@@ -34,7 +34,7 @@ This is a nono sandbox denial, **not** macOS TCC, **not** Unix file permissions,
 Run `nono why` to understand exactly why the operation was blocked:
 
 ```bash
-nono why --path /path/that/failed --op read 2>/dev/null
+nono why --self --path /path/that/failed --op read 2>/dev/null
 ```
 
 This tells you:
@@ -80,7 +80,7 @@ The file contains:
 ## Common scenarios
 
 **"I need to read a config file outside the project"**
-Run `nono why --path /path/to/config --op read 2>/dev/null`, then offer the quick fix or a profile.
+Run `nono why --self --path /path/to/config --op read 2>/dev/null`, then offer the quick fix or a profile.
 
 **"I need to install a global package"**
 Global package managers write to system paths. Suggest project-local alternatives (e.g., `npx` instead of global install) or offer to write a profile.
@@ -89,4 +89,4 @@ Global package managers write to system paths. Suggest project-local alternative
 If the profile blocks network access, the user must use a profile that allows it. Offer to write one.
 
 **"I need to access another project directory"**
-Run `nono why --path /path/to/other/project --op readwrite 2>/dev/null`, then offer the quick fix or a profile.
+Run `nono why --self --path /path/to/other/project --op readwrite 2>/dev/null`, then offer the quick fix or a profile.

--- a/claude-autoresearch/bin/nono-hook-bash.sh
+++ b/claude-autoresearch/bin/nono-hook-bash.sh
@@ -32,7 +32,7 @@ Network: $NET
 
 DO NOT ask the user for permission. Take these steps in order, every time:
 
-1. Run \`nono why --path <blocked-path> --op read\` immediately. Include its output verbatim in your reply so the user sees the diagnosis.
+1. Run \`nono why --self --path <blocked-path> --op read\` immediately. Include its output verbatim in your reply so the user sees the diagnosis.
 2. Then present the user with these two options as their NEXT decision point:
 
    Option A (quick fix): exit and restart with the path allowed:

--- a/claude-autoresearch/bin/nono-hook.sh
+++ b/claude-autoresearch/bin/nono-hook.sh
@@ -32,7 +32,7 @@ Network: $NET
 
 DO NOT ask the user for permission. Take these steps in order, every time:
 
-1. Run \`nono why --path <blocked-path> --op read\` immediately. Include its output verbatim in your reply so the user sees the diagnosis.
+1. Run \`nono why --self --path <blocked-path> --op read\` immediately. Include its output verbatim in your reply so the user sees the diagnosis.
 2. Then present the user with these two options as their NEXT decision point:
 
    Option A (quick fix): exit and restart with the path allowed:

--- a/claude-autoresearch/policy.json
+++ b/claude-autoresearch/policy.json
@@ -1,6 +1,6 @@
 {
   "meta": { "name": "claude-code-autoresearch", "version": "1.0.0", "description": "Claude Code + GPU for autoresearch" },
-  "extends": "claude",
+  "extends": "nolabs-ai/claude",
   "allow_gpu": true,
   "filesystem": {
     "allow": ["$HOME/autoresearch-nono", "$HOME/.cache/autoresearch/ibd", "$HOME/.cache/autoresearch/tcga", "$HOME/.cache/autoresearch/climbmix", "$HOME/.cache/torch", "$HOME/.cache/uv", "$HOME/.cache/huggingface", "$HOME/.local/share/uv", "$HOME/.nv", "$HOME/.triton", "/tmp", "/dev/shm", "$HOME/.local/share/claude", "$HOME/.local/state/claude/locks"],

--- a/claude-autoresearch/skills/autoresearch/SKILL.md
+++ b/claude-autoresearch/skills/autoresearch/SKILL.md
@@ -57,7 +57,7 @@ If a file read, write, or bash command fails with EPERM, EACCES, or "Operation n
 1. **Do NOT retry** the same operation.
 2. Run `nono why` to diagnose:
    ```bash
-   nono why --path /path/that/failed --op read 2>/dev/null
+   nono why --self --path /path/that/failed --op read 2>/dev/null
    ```
 3. Present the user with options:
    - **Quick fix**: restart with `--allow /path/to/needed` added to the nono command

--- a/claude/bin/nono-hook-bash.sh
+++ b/claude/bin/nono-hook-bash.sh
@@ -35,7 +35,7 @@ Network: $NET
 
 DO NOT ask the user for permission. Take these steps in order, every time:
 
-1. Run \`nono why --path <blocked-path> --op read\` immediately. Include its output verbatim in your reply so the user sees the diagnosis.
+1. Run \`nono why --self --path <blocked-path> --op read\` immediately. Include its output verbatim in your reply so the user sees the diagnosis.
 2. Then present the user with these two options as their NEXT decision point:
 
    Option A (quick fix): exit and restart with the path allowed:

--- a/claude/bin/nono-hook.sh
+++ b/claude/bin/nono-hook.sh
@@ -35,7 +35,7 @@ Network: $NET
 
 DO NOT ask the user for permission. Take these steps in order, every time:
 
-1. Run \`nono why --path <blocked-path> --op read\` immediately. Include its output verbatim in your reply so the user sees the diagnosis.
+1. Run \`nono why --self --path <blocked-path> --op read\` immediately. Include its output verbatim in your reply so the user sees the diagnosis.
 2. Then present the user with these two options as their NEXT decision point:
 
    Option A (quick fix): exit and restart with the path allowed:

--- a/claude/skills/nono-sandbox/SKILL.md
+++ b/claude/skills/nono-sandbox/SKILL.md
@@ -32,7 +32,7 @@ If a file read, write, edit, or bash command fails with a permission error (EPER
 Run `nono why` to understand exactly why the operation was blocked:
 
 ```bash
-nono why --path /path/that/failed --op read 2>/dev/null
+nono why --self --path /path/that/failed --op read 2>/dev/null
 ```
 
 This tells you:
@@ -78,7 +78,7 @@ The file contains:
 ## Common scenarios
 
 **"I need to read a config file outside the project"**
-Run `nono why --path /path/to/config --op read 2>/dev/null`, then offer the quick fix or a profile.
+Run `nono why --self --path /path/to/config --op read 2>/dev/null`, then offer the quick fix or a profile.
 
 **"I need to install a global package"**
 Global package managers write to system paths. Suggest project-local alternatives (e.g., `npx` instead of global install) or offer to write a profile.
@@ -87,4 +87,4 @@ Global package managers write to system paths. Suggest project-local alternative
 If the profile blocks network access, the user must use a profile that allows it. Offer to write one.
 
 **"I need to access another project directory"**
-Run `nono why --path /path/to/other/project --op readwrite 2>/dev/null`, then offer the quick fix or a profile.
+Run `nono why --self --path /path/to/other/project --op readwrite 2>/dev/null`, then offer the quick fix or a profile.

--- a/codex/skills/nono-sandbox/SKILL.md
+++ b/codex/skills/nono-sandbox/SKILL.md
@@ -31,7 +31,7 @@ Do NOT suggest:
 
 Run `nono why` to see exactly why access was denied:
 
-    nono why --path /the/blocked/path --op read
+    nono why --self --path /the/blocked/path --op read
 
 The output names the rule that blocked the path and suggests the minimum grant to allow it.
 

--- a/copilot-cli/skills/copilot-sandbox/SKILL.md
+++ b/copilot-cli/skills/copilot-sandbox/SKILL.md
@@ -43,7 +43,7 @@ Everything else is blocked at the kernel level. There is no escalation path from
 Run `nono why` to see exactly why access was denied:
 
 ```bash
-nono why --path /the/blocked/path --op read
+nono why --self --path /the/blocked/path --op read
 ```
 
 The output names the rule that blocked the path and suggests the minimum grant to allow it.

--- a/openclaw/bin/nono-hook.sh
+++ b/openclaw/bin/nono-hook.sh
@@ -35,7 +35,7 @@ Network: $NET
 
 DO NOT suggest sudo, chmod, or system permission changes. Take these steps in order:
 
-1. Run \`nono why --path <blocked-path> --op read\` immediately. Include its output verbatim in your reply so the user sees the diagnosis.
+1. Run \`nono why --self --path <blocked-path> --op read\` immediately. Include its output verbatim in your reply so the user sees the diagnosis.
 2. Then present the user with these two options as their NEXT decision point:
 
    Option A (quick fix): exit and restart with the path allowed:

--- a/openclaw/skills/nono-sandbox/SKILL.md
+++ b/openclaw/skills/nono-sandbox/SKILL.md
@@ -3,7 +3,7 @@ name: nono-sandbox
 description: Diagnose and resolve permission denials when OpenClaw runs inside a nono security sandbox. Use this when a tool call, shell command, or file operation fails with "Operation not permitted", "Permission denied", EACCES, or EPERM — the cause is almost certainly the outer nono sandbox.
 ---
 
-**On any EPERM / EACCES / "Operation not permitted" tool or shell failure:** run `nono why --path <blocked-path> --op read` immediately and include its output verbatim in your reply. Do NOT suggest sudo, chmod, or system permission changes. Then offer the user exactly these two options:
+**On any EPERM / EACCES / "Operation not permitted" tool or shell failure:** run `nono why --self --path <blocked-path> --op read` immediately and include its output verbatim in your reply. Do NOT suggest sudo, chmod, or system permission changes. Then offer the user exactly these two options:
 
 - **Option A (quick fix):** `nono run --allow /path/to/needed -- openclaw`
 - **Option B (persistent fix):** draft a profile to `~/.config/nono/profile-drafts/<name>.json` extending `openclaw`, add the path under `"allow"` or `"read"`, then tell the user to run `nono profile promote <name>` and start sessions with `nono run --profile <name> -- openclaw`
@@ -33,7 +33,7 @@ When you see any of these on a file, shell, or tool failure, it is a nono bounda
 
 Run `nono why` to see exactly why access was denied:
 
-    nono why --path /the/blocked/path --op read
+    nono why --self --path /the/blocked/path --op read
 
 The output names the rule that blocked the path and suggests the minimum grant to allow it.
 

--- a/opencode/plugin/nono-sandbox.ts
+++ b/opencode/plugin/nono-sandbox.ts
@@ -98,8 +98,8 @@ function buildGuidance(caps: Caps, blockedPath: string | null): string {
   const net = caps.net_blocked ? "blocked" : "allowed"
   const display = blockedPath ?? "<blocked-path>"
   const whyCmd = blockedPath
-    ? `nono why --path ${blockedPath} --op read`
-    : "nono why --path <blocked-path> --op read"
+    ? `nono why --self --path ${blockedPath} --op read`
+    : "nono why --self --path <blocked-path> --op read"
   const allowCmd = blockedPath
     ? `nono run --allow ${blockedPath} -- opencode`
     : "nono run --allow <blocked-path> -- opencode"
@@ -145,7 +145,7 @@ You are running inside nono, an OS-level security sandbox. nono enforces filesys
 sudo, chmod, chown, retries, or macOS Full Disk Access cannot grant access that nono has not allowed.${reattachNote}
 
 If a tool or shell command fails with "Operation not permitted", "Permission denied", EACCES, EPERM, landlock, or sandbox denied:
-1. Run: nono why --path <blocked-path> --op <read|write|readwrite>
+1. Run: nono why --self --path <blocked-path> --op <read|write|readwrite>
 2. Offer the user exactly two options:
    Option A: nono run --allow /path/to/needed -- opencode
    Option B: draft ${profileDraftsDir()}/<name>.json extending "opencode", then have the user run nono profile promote <name>

--- a/opencode/skills/nono-sandbox/SKILL.md
+++ b/opencode/skills/nono-sandbox/SKILL.md
@@ -5,7 +5,7 @@ version: 1.2.0
 platforms: [macos, linux]
 ---
 
-**On any EPERM / EACCES / "Operation not permitted" tool or shell failure:** run `nono why --path <blocked-path> --op read` immediately and include its output verbatim in your reply. Do NOT suggest sudo, chmod, or system permission changes. Then offer the user exactly these two options:
+**On any EPERM / EACCES / "Operation not permitted" tool or shell failure:** run `nono why --self --path <blocked-path> --op read` immediately and include its output verbatim in your reply. Do NOT suggest sudo, chmod, or system permission changes. Then offer the user exactly these two options:
 
 - **Option A (quick fix):** `nono run --allow /path/to/needed -- opencode`
 - **Option B (persistent fix):** draft a profile to `$XDG_CONFIG_HOME/nono/profile-drafts/<name>.json` extending `opencode`, add the path under `"allow"` or `"read"`, then tell the user to run `nono profile promote <name>` and start sessions with `nono run --profile <name> -- opencode`
@@ -37,7 +37,7 @@ Network-egress denials look different: a request to a host that is not on the sa
 
 Run `nono why` to see exactly why access was denied:
 
-    nono why --path /the/blocked/path --op read
+    nono why --self --path /the/blocked/path --op read
 
 Use `--op write` for write-only failures and `--op readwrite` when the operation needs both.
 


### PR DESCRIPTION
Since nono v0.74/0.75, `nono why` run from inside a sandbox without --self evaluates against the host/default profile instead of the running sandbox, silently reporting ALLOWED for paths the active profile actually denies. All pack skills/hooks instructing agents to run `nono why --path ... --op ...` for diagnosis were missing the flag, causing incorrect denial diagnoses. Adds --self to every such invocation across antigravity, claude, claude-autoresearch, codex, copilot-cli, openclaw, and opencode (kimchi already had it right).

Closes #17 