### PR TITLE
fix: correct stale author metadata and diagnostic drift across packs;bump versions

### DIFF
--- a/antigravity/bin/denial.txt
+++ b/antigravity/bin/denial.txt
@@ -8,7 +8,7 @@ Network: __NET__
 
 DO NOT ask the user for permission. Take these steps in order, every time:
 
-1. Run `nono why --path <blocked-path> --op read` immediately. Include its output verbatim in your reply so the user sees the diagnosis.
+1. Run `nono why --self --path <blocked-path> --op read` immediately. Include its output verbatim in your reply so the user sees the diagnosis.
 2. Then present the user with these two options as their NEXT decision point:
 
    Option A (quick fix): exit and restart with the path allowed:

--- a/antigravity/package.json
+++ b/antigravity/package.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "name": "antigravity",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Antigravity CLI (agy) plugin for working inside a nono sandbox. Ships a nono-sandbox skill plus a PostToolUse hook that surfaces sandbox-aware diagnostics on permission failures.",
   "license": "Apache-2.0",
   "platforms": [

--- a/antigravity/plugin.json
+++ b/antigravity/plugin.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Teaches the Antigravity CLI (agy) how to work inside a nono security sandbox. Provides sandbox-aware diagnostics on permission failures via a PostToolUse hook, plus a nono-sandbox skill.",
   "author": {
-    "name": "Always Further",
+    "name": "nolabs-ai",
     "url": "https://github.com/nolabs-ai"
   },
   "homepage": "https://nono.sh",

--- a/antigravity/policy.json
+++ b/antigravity/policy.json
@@ -6,7 +6,7 @@
     "name": "antigravity",
     "version": "1.0.0",
     "description": "Runtime-discovered path additions for agy",
-    "author": null
+    "author": "nolabs-ai"
   },
   "security": {
     "signal_mode": null,

--- a/claude-autoresearch/.claude-plugin/plugin.json
+++ b/claude-autoresearch/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "Teaches Claude Code how to run autoresearch autonomous ML loops inside a nono security sandbox with GPU access.",
   "author": {
-    "name": "Kexin Xu",
-    "url": "https://github.com/Kexin-xu-01"
+    "name": "nolabs-ai",
+    "url": "https://github.com/nolabs-ai"
   },
   "homepage": "https://github.com/nolabs-ai/autoresearch-nono",
   "repository": "https://github.com/nolabs-ai/nono-packs/tree/main/claude-autoresearch",

--- a/claude-autoresearch/package.json
+++ b/claude-autoresearch/package.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "name": "claude-autoresearch",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "nono profile and Claude Code plugin for running autoresearch autonomous ML loops. GPU-enabled sandbox profile for A100/CUDA workloads with IBD, TCGA, and climbmix corpora.",
   "license": "Apache-2.0",
   "platforms": ["linux"],

--- a/claude-autoresearch/wiring/marketplace.json
+++ b/claude-autoresearch/wiring/marketplace.json
@@ -9,8 +9,8 @@
       "description": "Teaches Claude Code how to run autoresearch autonomous ML loops inside a nono security sandbox with GPU access.",
       "version": "1.0.0",
       "author": {
-        "name": "Kexin Xu",
-        "url": "https://github.com/Kexin-xu-01"
+        "name": "nolabs-ai",
+        "url": "https://github.com/nolabs-ai"
       },
       "source": "./plugins/claude-autoresearch",
       "category": "security",

--- a/claude/.claude-plugin/plugin.json
+++ b/claude/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Teaches Claude Code how to work inside a nono security sandbox. Provides sandbox-aware diagnostics on permission failures and instructions for capability management.",
   "author": {
-    "name": "Always Further",
+    "name": "nolabs-ai",
     "url": "https://github.com/nolabs-ai"
   },
   "homepage": "https://nono.sh",

--- a/claude/package.json
+++ b/claude/package.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "name": "claude",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "description": "Claude Code plugin and matching nono profile. Provides sandbox-aware diagnostics on permission failures and ships the claude-code profile via the registry.",
   "license": "Apache-2.0",
   "platforms": [

--- a/claude/wiring/marketplace.json
+++ b/claude/wiring/marketplace.json
@@ -9,7 +9,7 @@
       "description": "Teaches Claude Code how to work inside a nono security sandbox. Provides sandbox-aware diagnostics on permission failures and instructions for capability management.",
       "version": "1.0.0",
       "author": {
-        "name": "Always Further",
+        "name": "nolabs-ai",
         "url": "https://github.com/nolabs-ai"
       },
       "source": "./plugins/nono",

--- a/codex/package.json
+++ b/codex/package.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "name": "codex",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Teaches OpenAI Codex how to work inside a nono security sandbox.",
   "license": "Apache-2.0",
   "platforms": ["macos", "linux"],

--- a/copilot-cli/NOTES.md
+++ b/copilot-cli/NOTES.md
@@ -41,7 +41,7 @@ Verified from `nono/crates/nono-cli/src/package.rs` and `nono/crates/nono-cli/sr
 - Valid artifact types: `profile`, `instruction`, `trust_policy`, `groups`, `plugin`
 - Valid wiring directive types: `symlink`, `write_file`, `json_merge`, `json_array_append`, `toml_block`
 - Wiring variables available: `$PACK_DIR`, `$NS`, `$PLUGIN`, `$HOME`, `$XDG_CONFIG_HOME`, `$NOW`
-- `min_nono_version: "0.44.0"` matches `claude` and `codex` packs (wiring system stable from this version)
+- `min_nono_version: "0.58.0"`
 
 ---
 

--- a/copilot-cli/bin/nono-hook-bash.sh
+++ b/copilot-cli/bin/nono-hook-bash.sh
@@ -4,7 +4,7 @@
 #
 # Fires on PostToolUse for all tools. Filters to bash tool only, then
 # inspects the tool result for sandbox-denial patterns. Reads context
-# from ../context/denial.txt and injects it so the agent can guide the user.
+# from denial.txt and injects it so the agent can guide the user.
 #
 # Input schema (VS Code compat):
 #   { hook_event_name, tool_name, tool_input, tool_result: { result_type, text_result_for_llm } }

--- a/copilot-cli/bin/nono-hook-session.sh
+++ b/copilot-cli/bin/nono-hook-session.sh
@@ -3,13 +3,13 @@
 # Version: 0.1.0
 #
 # Brief boundary statement at session start. Reads context from
-# ../context/session.txt and injects it into the session.
+# session.txt and injects it into the session.
 #
 # Input schema (VS Code compat): { hook_event_name, session_id, timestamp, cwd, source }
 # Output schema: { hookSpecificOutput: { hookEventName, additionalContext } }
 # NOTE: output schema needs verification against Copilot CLI hook runtime.
 # See NOTES.md for details.
-NONO_HOOK_DEBUG=-
+NONO_HOOK_DEBUG=0
 LOG_FILE="${NONO_HOOK_LOG:-$HOME/.copilot/nono-hook.log}"
 log() { [ "${NONO_HOOK_DEBUG:-0}" = "1" ] && echo "$(date -Iseconds) [nono-hook-session] $*" >> "$LOG_FILE"; }
 

--- a/copilot-cli/bin/nono-hook.sh
+++ b/copilot-cli/bin/nono-hook.sh
@@ -2,7 +2,7 @@
 # nono-hook.sh — GitHub Copilot CLI nono sandbox diagnostics hook
 # Version: 0.1.0
 #
-# Fires on PostToolUseFailure. Reads context from ../context/denial.txt,
+# Fires on PostToolUseFailure. Reads context from denial.txt,
 # substitutes live capability data, and injects it so the agent understands
 # what was blocked and how the user can fix it.
 #
@@ -10,7 +10,7 @@
 # Output schema: { hookSpecificOutput: { hookEventName, additionalContext } }
 # NOTE: output schema needs verification against Copilot CLI hook runtime.
 # See NOTES.md for details.
-NONO_HOOK_DEBUG=1
+NONO_HOOK_DEBUG=0
 LOG_FILE="${NONO_HOOK_LOG:-$HOME/.copilot/nono-hook.log}"
 log() { [ "${NONO_HOOK_DEBUG:-0}" = "1" ] && echo "$(date -Iseconds) [nono-hook] $*" >> "$LOG_FILE"; }
 

--- a/copilot-cli/package.json
+++ b/copilot-cli/package.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "name": "copilot-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "GitHub Copilot CLI plugin and matching nono profile. Provides sandbox-aware diagnostics on permission failures via PostToolUseFailure, PostToolUse, and SessionStart hooks.",
   "license": "Apache-2.0",
   "platforms": [

--- a/copilot-cli/plugin.json
+++ b/copilot-cli/plugin.json
@@ -3,11 +3,11 @@
     "description": "Teaches GitHub Copilot CLI how to work inside a nono security sandbox. Provides sandbox-aware diagnostics on permission failures via PostToolUseFailure, PostToolUse, and SessionStart hooks.",
     "version": "0.1.0",
     "author": {
-        "name": "Always Further",
+        "name": "nolabs-ai",
         "url": "https://github.com/nolabs-ai"
     },
     "homepage": "https://nono.sh",
-    "repository": "https://github.com/nolabs-ai/nono-packs/tree/main/github-copilot",
+    "repository": "https://github.com/nolabs-ai/nono-packs/tree/main/copilot-cli",
     "license": "Apache-2.0",
     "keywords": ["nono", "sandbox", "security", "capabilities", "copilot"],
     "skills": "./skills/",

--- a/copilot-cli/wiring/enabled-plugin.json
+++ b/copilot-cli/wiring/enabled-plugin.json
@@ -2,7 +2,7 @@
     {
         "name": "nono",
         "marketplace": "$NS",
-        "version": "1.0.1",
+        "version": "0.1.0",
         "installed_at": "$NOW",
         "enabled": true,
         "cache_path": "$HOME/.copilot/installed-plugins/$NS/nono"

--- a/copilot-cli/wiring/marketplace.json
+++ b/copilot-cli/wiring/marketplace.json
@@ -3,7 +3,7 @@
       "nolabs-ai": {      
         "source": {      
           "source": "github",
-          "repo": "$NS/nono-packs-copilot"
+          "repo": "$NS/nono-packs"
         }                                 
       }  
     }  

--- a/goose/package.json
+++ b/goose/package.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "name": "goose",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Goose CLI profile and Open Plugin for working inside a nono sandbox. Ships sandbox-aware hooks and a Goose-native skill.",
   "license": "Apache-2.0",
   "platforms": [

--- a/hermes/README.md
+++ b/hermes/README.md
@@ -363,7 +363,7 @@ nono why --self --path /path/to/some/file --op read
 
 ### Agent Profile Expansion and Promotion
 
-When a sandbox denial occurs, the agent can draft profile changes, but it cannot directly edit active profiles under `~/.config/nono/profiles`. This keeps policy changes behind an explicit user promotion step. When the agent drafts a profile change, it writes the proposed profile to `~/.config/nono/drafts/<name>.json`. Review the draft, then promote it to make it active:
+When a sandbox denial occurs, the agent can draft profile changes, but it cannot directly edit active profiles under `~/.config/nono/profiles`. This keeps policy changes behind an explicit user promotion step. When the agent drafts a profile change, it writes the proposed profile to `~/.config/nono/profile-drafts/<name>.json`. Review the draft, then promote it to make it active:
 
 ```bash
 nono profile validate --draft hermes-agent

--- a/hermes/package.json
+++ b/hermes/package.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "name": "hermes",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Hermes Agent plugin, skill, and matching nono profile. Provides sandbox-aware diagnostics and safer Hermes defaults when running inside nono.",
   "license": "Apache-2.0",
   "platforms": ["macos", "linux"],

--- a/kimchi/package.json
+++ b/kimchi/package.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "name": "kimchi",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Kimchi Coding Agent package and matching nono profile. Provides sandbox-aware diagnostics on permission failures and ships the kimchi profile via the registry.",
   "license": "Apache-2.0",
   "platforms": ["macos", "linux"],

--- a/kimchi/policy.json
+++ b/kimchi/policy.json
@@ -4,7 +4,7 @@
     "name": "kimchi",
     "version": "1.0.0",
     "description": "Kimchi Coding Agent profile (registry-managed)",
-    "author": "CastAI"
+    "author": "CastAI, nolabs-ai"
   },
   "groups": {
     "include": [

--- a/openclaw/.openclaw-plugin/plugin.json
+++ b/openclaw/.openclaw-plugin/plugin.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Teaches OpenClaw how to work inside a nono security sandbox. Provides sandbox-aware diagnostics on permission failures and instructions for capability management.",
   "author": {
-    "name": "Always Further",
+    "name": "nolabs-ai",
     "url": "https://github.com/nolabs-ai"
   },
   "homepage": "https://nono.sh",

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -24,7 +24,7 @@ All sandboxed OpenClaw instances on the same machine share `$TMPDIR/openclaw-$UI
 
 ## Installation
 
-Requires nono ≥ 0.44.0.
+Requires nono ≥ 0.47.0.
 
 ```bash
 nono pull nolabs-ai/openclaw
@@ -77,7 +77,7 @@ The profile:
 - Name: `openclaw`
 - Platforms: `macos`, `linux`
 - License: `Apache-2.0`
-- Min nono version: `0.44.0`
+- Min nono version: `0.47.0`
 
 ## Directory Layout
 

--- a/openclaw/nono-hooks/index.js
+++ b/openclaw/nono-hooks/index.js
@@ -54,7 +54,7 @@ module.exports = function register(api) {
       'Network: ' + net,
       '',
       'Next steps (in order):',
-      '1. Run `nono why --path <blocked-path> --op read` immediately.',
+      '1. Run `nono why --self --path <blocked-path> --op read` immediately.',
       '   Include its output verbatim in your reply.',
       '2. Present the user with exactly these two options:',
       '   Option A (quick fix):  nono run --allow /path/to/needed -- openclaw',

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "name": "openclaw",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "OpenClaw plugin and matching nono profile. Provides sandbox-aware diagnostics on permission failures and ships the openclaw profile via the registry.",
   "license": "Apache-2.0",
   "platforms": ["macos", "linux"],

--- a/openclaw/settings.json
+++ b/openclaw/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/bin/nono-hook.sh"
+            "command": "${PLUGIN_ROOT}/bin/nono-hook.sh"
           }
         ]
       }

--- a/openclaw/wiring/marketplace.json
+++ b/openclaw/wiring/marketplace.json
@@ -9,7 +9,7 @@
       "description": "Teaches OpenClaw how to work inside a nono security sandbox. Provides sandbox-aware diagnostics on permission failures and instructions for capability management.",
       "version": "1.0.0",
       "author": {
-        "name": "Always Further",
+        "name": "nolabs-ai",
         "url": "https://github.com/nolabs-ai"
       },
       "source": "./plugins/nono",
@@ -25,7 +25,7 @@
       "description": "Native message_sending hook that fires nono sandbox diagnostics for non-Claude model sessions (Gemini, etc.). Works alongside the nono plugin.",
       "version": "1.0.0",
       "author": {
-        "name": "Always Further",
+        "name": "nolabs-ai",
         "url": "https://github.com/nolabs-ai"
       },
       "source": "./plugins/nono-hooks",

--- a/opencode/README.md
+++ b/opencode/README.md
@@ -92,7 +92,7 @@ nono remove nolabs-ai/opencode
 ## Package Metadata
 
 - Name: `opencode`
-- Version: `0.0.6`
+- Version: `0.1.1`
 - Pack type: `agent`
 - Platforms: `macos`, `linux`
 - License: `Apache-2.0`

--- a/opencode/package.json
+++ b/opencode/package.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "name": "opencode",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "opencode plugin and matching nono profile. Provides sandbox-aware diagnostics, credential injection, detach/attach support, and a nono-status command when running inside a nono sandbox.",
   "license": "Apache-2.0",
   "platforms": [

--- a/pi/README.md
+++ b/pi/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="./assets/logo.png" alt="nono codex" width="500" />
+  <img src="./assets/logo.png" alt="nono pi" width="500" />
 </p>
 
 

--- a/pi/package.json
+++ b/pi/package.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "name": "pi",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pi Coding Agent package and matching nono profile. Provides sandbox-aware diagnostics on permission failures and ships the pi profile via the registry.",
   "license": "Apache-2.0",
   "platforms": [


### PR DESCRIPTION


Fixes across pack manifests found during a full pack-by-pack audit:

- kimchi: policy.json author was "CastAI" only; now credits both CastAI and nolabs-ai
- claude-autoresearch: plugin.json/marketplace.json attributed to "Kexin Xu" instead of nolabs-ai
- openclaw: nono-hooks/index.js and settings.json had drifted from the --self flag fix and used the wrong plugin-root env var (${CLAUDE_PLUGIN_ROOT} instead of ${PLUGIN_ROOT}); README min_nono_version was stale
- antigravity: bin/denial.txt missing the --self flag; policy.json author was null
- copilot-cli: broken repository URL, marketplace.json repo field typo, stale ../context/ path comments in bin scripts, inconsistent NONO_HOOK_DEBUG values, and a version mismatch in wiring/enabled-plugin.json
- pi: README logo alt text said "nono codex"
- hermes: README referenced the wrong profile-drafts path
- Replaced all remaining "Always Further" author values with "nolabs-ai" for consistency across claude, openclaw, copilot-cli, and antigravity manifests