### PR TITLE
fix(claude): replace symlink asset operation with explicit file writes

### DIFF
--- a/claude/package.json
+++ b/claude/package.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "name": "claude",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Claude Code plugin and matching nono profile. Provides sandbox-aware diagnostics on permission failures and ships the claude-code profile via the registry.",
   "license": "Apache-2.0",
   "platforms": [
@@ -78,9 +78,34 @@
       "dest": "$NONO_CONFIG/profile-drafts/.nono-claude-pack-marker"
     },
     {
-      "type": "symlink",
-      "link": "$HOME/.claude/plugins/marketplaces/$NS/plugins/nono",
-      "target": "$PACK_DIR"
+      "type": "write_file",
+      "source": ".claude-plugin/plugin.json",
+      "dest": "$HOME/.claude/plugins/marketplaces/$NS/plugins/nono/.claude-plugin/plugin.json"
+    },
+    {
+      "type": "write_file",
+      "source": "hooks/hooks.json",
+      "dest": "$HOME/.claude/plugins/marketplaces/$NS/plugins/nono/hooks/hooks.json"
+    },
+    {
+      "type": "write_file",
+      "source": "bin/nono-hook.sh",
+      "dest": "$HOME/.claude/plugins/marketplaces/$NS/plugins/nono/bin/nono-hook.sh"
+    },
+    {
+      "type": "write_file",
+      "source": "bin/nono-hook-bash.sh",
+      "dest": "$HOME/.claude/plugins/marketplaces/$NS/plugins/nono/bin/nono-hook-bash.sh"
+    },
+    {
+      "type": "write_file",
+      "source": "bin/ensure-dirs.sh",
+      "dest": "$HOME/.claude/plugins/marketplaces/$NS/plugins/nono/bin/ensure-dirs.sh"
+    },
+    {
+      "type": "write_file",
+      "source": "skills/nono-sandbox/SKILL.md",
+      "dest": "$HOME/.claude/plugins/marketplaces/$NS/plugins/nono/skills/nono-sandbox/SKILL.md"
     },
     {
       "type": "write_file",


### PR DESCRIPTION
Update the plugin manifest installation steps to write files directly into the Claude marketplace plugin directory rather than relying on a symlink to the package contents. Bump package version to 0.1.2.

Resolves: #24 