### PR TITLE
docs(mistral-vibe): execute post_tool hook with explicit bash shell

### DIFF
--- a/mistral-vibe/README.md
+++ b/mistral-vibe/README.md
@@ -15,7 +15,7 @@ nono run --profile mistral-vibe --allow-cwd -- vibe
 
 The profile includes Vibe's `~/.vibe` configuration and state, the `uv` tool tree used by the standard installer, common developer runtimes, and read access to the Vibe launcher in `~/.local/bin`. This is required because the launcher is a Python script whose interpreter normally lives under `~/.local/share/uv/tools/mistral-vibe`.
 
-The package also installs a Vibe `post_tool` hook in `~/.vibe/hooks.toml`. When a tool reports a likely nono denial, the hook adds the active capabilities and the next steps for diagnosing the boundary or creating a profile extension. The hook is passive for ordinary tool failures and uses Vibe's native hook contract.
+The package also installs a Vibe `post_tool` hook in `~/.vibe/hooks.toml`. When a tool reports a likely nono denial, the hook adds the active capabilities and the next steps for diagnosing the boundary or creating a profile extension. The hook is passive for ordinary tool failures, uses Vibe's native hook contract, and is invoked through `/bin/bash` so package installation does not need to preserve executable file permissions.
 
 The Mistral credential route is defined but not enabled by default. Add `"mistral"` to `network.credentials` in a profile extending `nolabs-ai/mistral-vibe` if you want nono to inject `MISTRAL_API_KEY` from the host keychain.
 

--- a/mistral-vibe/package.json
+++ b/mistral-vibe/package.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "name": "mistral-vibe",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Mistral Vibe CLI package and matching nono profile for running Vibe inside the nono security sandbox.",
   "license": "Apache-2.0",
   "platforms": ["macos", "linux"],

--- a/mistral-vibe/wiring/hooks.toml
+++ b/mistral-vibe/wiring/hooks.toml
@@ -2,7 +2,7 @@
 name = "nono-sandbox-denial"
 type = "post_tool"
 match = "*"
-command = "$HOME/.vibe/hooks/nono-sandbox.sh"
+command = "/bin/bash \"$HOME/.vibe/hooks/nono-sandbox.sh\""
 timeout = 5.0
 strict = false
 description = "Explain nono sandbox denials and profile remediation steps."


### PR DESCRIPTION
Invoke the `nono-sandbox.sh` hook via `/bin/bash` in `hooks.toml` so package installation does not rely on preserving executable file permissions.

- Update package version to 0.1.1
- Document explicit bash invocation requirement in README