### PR TITLE
fix: verify nono provenance before permission remediation

### DIFF
--- a/antigravity/skills/nono-sandbox/SKILL.md
+++ b/antigravity/skills/nono-sandbox/SKILL.md
@@ -17,7 +17,7 @@ nono applies an allow-list of filesystem paths and network rules before your pro
 
 ## When an operation is denied
 
-If a file read, write, edit, or shell command fails with a permission error (EPERM, EACCES, "Operation not permitted", "Permission denied"):
+Output that explicitly names nono as the denying sandbox is conclusive. `landlock` and `sandbox: deny` signal sandbox enforcement but do not identify its provenance; generic EPERM, EACCES, "Operation not permitted", and "Permission denied" are also ambiguous. With a concrete path, run `nono why --self`; a successful result with status `DENIED` confirms the nono boundary, even when the reason is `path_not_granted` and no policy source is reported. If no path is available or `nono why` does not successfully report `DENIED`, report: `Nono sandbox unconfirmed; this permission failure needs a non-sandbox diagnosis.`
 
 1. **Do NOT retry** the same operation or try alternative paths.
 2. **Do NOT attempt workarounds** such as:
@@ -27,7 +27,7 @@ If a file read, write, edit, or shell command fails with a permission error (EPE
    - Suggesting the user run commands manually from another terminal
 3. **Do NOT apologize repeatedly** or suggest you will "try another approach" — there is no other approach.
 
-This is a nono sandbox denial, **not** macOS TCC, **not** Unix file permissions, and **not** an Antigravity approval prompt.
+After nono is confirmed, this is a nono sandbox denial, **not** macOS TCC, **not** Unix file permissions, and **not** an Antigravity approval prompt.
 
 ## Diagnosing the denial
 
@@ -43,6 +43,8 @@ This tells you:
 - A suggested fix (e.g., `--allow-file /path/to/file`)
 
 Always run `nono why` before telling the user what to do. It gives you the precise diagnosis.
+
+Never infer the active profile. Use a profile name supplied in the user's launch context, or ask which profile they started with before drafting.
 
 ## Helping the user
 

--- a/claude-autoresearch/skills/autoresearch/SKILL.md
+++ b/claude-autoresearch/skills/autoresearch/SKILL.md
@@ -52,7 +52,7 @@ The `claude-code-autoresearch` profile (installed by this pack) already includes
 
 ## When an operation is denied
 
-If a file read, write, or bash command fails with EPERM, EACCES, or "Operation not permitted":
+Output that explicitly names nono as the denying sandbox is conclusive. `landlock` and `sandbox: deny` signal sandbox enforcement but do not identify its provenance; generic EPERM, EACCES, and "Operation not permitted" are also ambiguous. With a concrete path, run `nono why --self`; a successful result with status `DENIED` confirms the nono boundary, even when the reason is `path_not_granted` and no policy source is reported. If no path is available or `nono why` does not successfully report `DENIED`, report: `Nono sandbox unconfirmed; this permission failure needs a non-sandbox diagnosis.`
 
 1. **Do NOT retry** the same operation.
 2. Run `nono why` to diagnose:
@@ -61,7 +61,7 @@ If a file read, write, or bash command fails with EPERM, EACCES, or "Operation n
    ```
 3. Present the user with options:
    - **Quick fix**: restart with `--allow /path/to/needed` added to the nono command
-   - **Profile edit**: add the path to `~/.config/nono/profiles/claude-code-autoresearch.json` under `filesystem.allow`
+   - **Profile draft**: use the active profile supplied in the user's launch context; if it is absent, ask which profile they started with, then draft an extending profile with the path under `filesystem.allow` and promote it outside the sandbox
 
 ## Common ML training permission issues
 

--- a/claude/skills/nono-sandbox/SKILL.md
+++ b/claude/skills/nono-sandbox/SKILL.md
@@ -17,7 +17,7 @@ nono applies an allow-list of filesystem paths and network rules before your pro
 
 ## When an operation is denied
 
-If a file read, write, edit, or bash command fails with a permission error (EPERM, EACCES, "Operation not permitted", "Permission denied"):
+Output that explicitly names nono as the denying sandbox is conclusive. `landlock` and `sandbox: deny` signal sandbox enforcement but do not identify its provenance; generic EPERM, EACCES, "Operation not permitted", and "Permission denied" are also ambiguous. With a concrete path, run `nono why --self`; a successful result with status `DENIED` confirms the nono boundary, even when the reason is `path_not_granted` and no policy source is reported. If no path is available or `nono why` does not successfully report `DENIED`, report: `Nono sandbox unconfirmed; this permission failure needs a non-sandbox diagnosis.`
 
 1. **Do NOT retry** the same operation or try alternative paths.
 2. **Do NOT attempt workarounds** such as:
@@ -41,6 +41,8 @@ This tells you:
 - A suggested fix (e.g., `--allow-file /path/to/file`)
 
 Always run `nono why` before telling the user what to do. It gives you the precise diagnosis.
+
+Never infer the active profile. Use a profile name supplied in the user's launch context, or ask which profile they started with before drafting.
 
 ## Helping the user
 

--- a/codex/skills/nono-sandbox/SKILL.md
+++ b/codex/skills/nono-sandbox/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nono-sandbox
-description: Diagnose and resolve permission denials when Codex runs inside a nono security sandbox. Use this when a Bash command, apply_patch, or MCP tool fails with "sandbox-exec: sandbox_apply: Operation not permitted", "Operation not permitted", "Permission denied", EACCES, EPERM, landlock, or sandbox-denied output. Do not merely report the failure: explain it is a nono OS sandbox boundary, avoid TCC/chmod/sudo advice, and offer the two fixes: restart once with nono run --allow, or draft a persistent profile in ~/.config/nono/profile-drafts for nono profile promote.
+description: Diagnose and resolve confirmed nono sandbox denials when Codex runs inside nono. Explicit nono output is conclusive; generic permission failures require `nono why` or a clear non-sandbox diagnostic outcome before remediation.
 ---
 
 # Working inside a nono sandbox
@@ -9,18 +9,17 @@ The user has launched you with `nono run --profile <name> -- codex`. nono enforc
 
 ## Identifying a sandbox denial
 
-The denial signature is in the failed tool's output:
+Only output that explicitly names nono as the denying sandbox is conclusive by itself. These markers signal sandbox enforcement but do not identify its provenance:
 
 - "sandbox-exec: sandbox_apply: Operation not permitted"
-- "Operation not permitted"
-- "Permission denied"
-- "EACCES" / "EPERM"
 - "landlock"
 - "sandbox: deny"
 
-When you see any of these on a Bash, apply_patch, or MCP file-tool failure, it is a nono boundary — not macOS TCC, not Full Disk Access, not Unix file permissions, not a Codex approval. On macOS, `sandbox-exec: sandbox_apply: Operation not permitted` often means Codex tried to apply its own sandbox inside the already-running nono Seatbelt sandbox; treat it as the same capability problem.
+On macOS, `sandbox-exec: sandbox_apply: Operation not permitted` can mean Codex tried to apply its own sandbox inside another Seatbelt sandbox; investigate it as a sandbox conflict without assuming nono caused it.
 
-Do NOT suggest:
+Generic `Operation not permitted`, `Permission denied`, `EACCES`, and `EPERM` are also ambiguous. If a concrete path is available, run `nono why --self --path <path> --op <needed-op>`; a successful result with status `DENIED` confirms the nono boundary, even when the reason is `path_not_granted` and no policy source is reported. If the path is unavailable or `nono why` does not successfully report `DENIED`, report: `Nono sandbox unconfirmed; this permission failure needs a non-sandbox diagnosis.` Do not offer a profile change until nono is confirmed.
+
+For a confirmed nono denial, do NOT suggest:
 
 - System Settings / Privacy & Security
 - `chmod`, `chown`, `sudo`
@@ -29,7 +28,7 @@ Do NOT suggest:
 
 ## Diagnosing
 
-Run `nono why` to see exactly why access was denied:
+For a concrete path, run `nono why` to see whether nono denied access:
 
     nono why --self --path /the/blocked/path --op read
 
@@ -53,11 +52,11 @@ If `~/.config/nono/profile-drafts` does not exist or cannot be written, or `nono
 
 Create the draft with the pack helper. Do not use `mkdir`, `printf`, `cat`, heredocs, shell redirection, or inline JSON to write profile drafts.
 
-Do not run shell/file checks to discover the active profile; those checks may themselves be blocked by the current sandbox. For this local dev install, assume `codex-dev` unless the user says they launched Codex with a custom profile. Registry installs should use `codex`. Ask which profile they started with only when the user says they launched Codex with a custom profile.
+Do not run shell/file checks to discover the active profile; those checks may themselves be blocked by the current sandbox. Never infer it from the install type. Use the profile name supplied in the user's launch context; if it is absent, ask which profile they started with before drafting.
 
 For read-only directory access, run:
 
-    ~/.codex/bin/nono-draft-profile --name codex-documents --extends codex-dev --read /path/to/needed
+    ~/.codex/bin/nono-draft-profile --name codex-documents --extends <active-profile> --read /path/to/needed
 
 For read+write directory access, use `--allow` instead of `--read`. For a single file, use `--read-file` or `--allow-file`.
 

--- a/codex/wiring/codex-block.toml
+++ b/codex/wiring/codex-block.toml
@@ -1,16 +1,15 @@
 developer_instructions = """
-When a tool output includes `sandbox-exec: sandbox_apply: Operation not permitted`, `Operation not permitted`, `Permission denied`, `EACCES`, `EPERM`, `landlock`, or `sandbox denied`, treat it as the outer nono OS sandbox boundary, not macOS TCC, Full Disk Access, Unix permissions, chmod/chown/sudo, or a Codex approval issue.
+Only output that explicitly names nono as the denying sandbox is conclusive by itself. `sandbox-exec: sandbox_apply: Operation not permitted`, `landlock`, and `sandbox denied` signal sandbox enforcement but do not identify its provenance; generic `Operation not permitted`, `Permission denied`, `EACCES`, and `EPERM` are also ambiguous. When a concrete path is known, run `nono why --self --path <path> --op <needed-op>`; a successful result with status `DENIED` confirms the nono boundary, even when the reason is `path_not_granted` and no policy source is reported. If no path is available or `nono why` does not successfully report `DENIED`, report: `Nono sandbox unconfirmed; this permission failure needs a non-sandbox diagnosis.`
 
-Do not suggest System Settings, Full Disk Access, chmod, chown, sudo, or bypassing Codex permissions for these errors. Explain that nono must be restarted with the needed capability.
+For a confirmed nono denial, do not suggest System Settings, Full Disk Access, chmod, chown, sudo, or bypassing Codex permissions. Explain that nono must be restarted with the needed capability.
 
-Offer exactly these options:
+Only after confirming a nono denial, offer exactly these options:
 A) One-off: exit and restart with `nono run --allow <absolute-blocked-path> -- codex`.
 B) Persistent: draft a JSON profile under `~/.config/nono/profile-drafts/`, tell the user to run `nono profile promote <name>`, then restart with `nono run --profile <name> -- codex`.
 
 If the user chooses B:
 - Do not run shell/file checks to discover the active profile; those checks may themselves be blocked by the current sandbox.
-- For this local dev install, assume the active profile is `codex-dev` unless the user says they launched Codex with a custom profile. Registry installs should use `codex`.
-- Ask which profile they started with only when the user says they launched Codex with a custom profile.
+- Never infer the active profile from the install type. Use the profile name supplied in the user's launch context; if it is absent, ask which profile they started with before drafting.
 - Use a concrete draft name such as `codex-documents`.
 - Do not use `mkdir`, `printf`, `cat`, heredocs, shell redirection, or inline JSON to write the draft.
 - Run the pack helper instead:
@@ -19,7 +18,7 @@ If the user chooses B:
 - For a single file, use `--read-file` or `--allow-file` instead.
 - If Codex asks for approval to write under `~/.config/nono/profile-drafts/`, explain that this is Codex's local write approval for creating the draft file; it is not an OS sandbox capability grant.
 
-If the blocked path is unclear, ask for the path or run `nono why --path <path> --op read` when a concrete path is available.
+If the blocked path is unclear, ask for it. When a concrete path is available, run `nono why --self --path <path> --op <needed-op>`.
 """
 
 [marketplaces.nolabs-ai]

--- a/copilot-cli/skills/copilot-sandbox/SKILL.md
+++ b/copilot-cli/skills/copilot-sandbox/SKILL.md
@@ -9,15 +9,14 @@ The user has launched you with `nono run --profile <profile> -- copilot`. nono e
 
 ## Identifying a sandbox denial
 
-The denial signature is in the failed tool's output:
+Only output that explicitly names nono as the denying sandbox is conclusive by itself. These markers signal sandbox enforcement but do not identify its provenance:
 
-- "Operation not permitted"
-- "Permission denied"
-- "EACCES" / "EPERM"
 - "landlock"
 - "sandbox: deny"
 
-When you see any of these on a `bash`, `view`, `edit`, or `create` tool failure, it is a nono boundary — not macOS TCC, not Full Disk Access, not Unix file permissions, not a Copilot approval. Do NOT suggest:
+Generic "Operation not permitted", "Permission denied", EACCES, and EPERM are also ambiguous. If a concrete path is available, run `nono why --self --path <path> --op <needed-op>`; a successful result with status `DENIED` confirms the nono boundary, even when the reason is `path_not_granted` and no policy source is reported. Otherwise report: `Nono sandbox unconfirmed; this permission failure needs a non-sandbox diagnosis.`
+
+For a confirmed nono denial, do NOT suggest:
 
 - System Settings / Privacy & Security
 - `chmod`, `chown`, `sudo`
@@ -49,6 +48,8 @@ nono why --self --path /the/blocked/path --op read
 The output names the rule that blocked the path and suggests the minimum grant to allow it.
 
 Always run `nono why` before telling the user what to do.
+
+Never infer the active profile. Use a profile name supplied in the user's launch context, or ask which profile they started with before drafting.
 
 ## Two options to present to the user
 

--- a/hermes/plugin/nono-sandbox/skills/nono-sandbox/SKILL.md
+++ b/hermes/plugin/nono-sandbox/skills/nono-sandbox/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nono-sandbox
-description: Diagnose and resolve permission denials when Hermes Agent runs inside a nono security sandbox. Use when terminal, file, browser, MCP, plugin, or skill operations fail with "Operation not permitted", "Permission denied", EACCES, EPERM, landlock, or sandbox-denied errors.
+description: Diagnose confirmed nono sandbox denials for Hermes Agent. Generic permission failures require `nono why` or a clear non-sandbox diagnostic outcome before remediation.
 version: 1.2.0
 platforms: [macos, linux]
 metadata:
@@ -21,15 +21,14 @@ This skill is bundled by the `nono-sandbox` Hermes plugin from the signed `nolab
 
 ## When to use this skill
 
-Use this skill when a Hermes tool or subprocess fails with:
+Use this skill to investigate a suspected nono denial. Only output that explicitly names nono as the denying sandbox is conclusive by itself. These markers signal sandbox enforcement but do not identify its provenance:
 
-- `Operation not permitted`
-- `Permission denied`
-- `EACCES` or `EPERM`
 - `landlock`
 - `sandbox: deny` or `sandbox denied`
 
 Common affected tools include `terminal`, `execute_code`, file read/write/edit tools, browser downloads, MCP subprocesses, plugin tools, and skill helper scripts.
+
+Generic `Operation not permitted`, `Permission denied`, `EACCES`, and `EPERM` are also ambiguous. With a concrete path, run `nono why --self`; a successful result with status `DENIED` confirms the nono boundary, even when the reason is `path_not_granted` and no policy source is reported. Otherwise report: `Nono sandbox unconfirmed; this permission failure needs a non-sandbox diagnosis.` Never infer the active profile; use the user's launch context or ask before drafting.
 
 ## Diagnosis
 
@@ -62,7 +61,7 @@ Present exactly two options to the user.
 Use this for a path needed only once:
 
 ```bash
-nono run --profile hermes --allow /path/to/needed -- hermes
+nono run --profile <active-profile> --allow /path/to/needed -- hermes
 ```
 
 Use `--read` instead of `--allow` when Hermes only needs view access.
@@ -73,7 +72,7 @@ Create a profile draft under `~/.config/nono/profile-drafts/<name>.json`:
 
 ```json
 {
-  "extends": "hermes",
+  "extends": "<active-profile>",
   "meta": { "name": "hermes-extra", "version": "1.0.0" },
   "filesystem": {
     "read": ["/path/to/needed"]

--- a/mistral-vibe/skills/nono-sandbox/SKILL.md
+++ b/mistral-vibe/skills/nono-sandbox/SKILL.md
@@ -6,18 +6,20 @@ user-invocable: false
 
 # Mistral Vibe inside nono
 
-When Vibe reports `Permission denied`, `Operation not permitted`, `EACCES`, or `EPERM`, treat it as a nono profile boundary. The operating system sandbox is the enforcement layer; retrying the same command or changing Vibe's own permissions cannot grant access.
+Only output that explicitly names nono as the denying sandbox is conclusive by itself. `landlock` and `sandbox: deny` signal sandbox enforcement but do not identify its provenance; `Permission denied`, `Operation not permitted`, `EACCES`, and `EPERM` are also ambiguous. When a concrete path is known, run `nono why --self --path <path> --op <needed-op>`; a successful result with status `DENIED` confirms the nono boundary, even when the reason is `path_not_granted` and no policy source is reported. Otherwise report: `Nono sandbox unconfirmed; this permission failure needs a non-sandbox diagnosis.` For a confirmed nono denial, the OS sandbox is the enforcement layer; retrying the same command or changing Vibe's own permissions cannot grant access.
+
+Never infer the active profile. Use the profile name supplied in the user's launch context, or ask which profile they started with before drafting or restarting.
 
 For a one-off path, restart with a narrow grant:
 
 ```bash
-nono run --profile mistral-vibe --allow /path/to/needed -- vibe
+nono run --profile <active-profile> --allow /path/to/needed -- vibe
 ```
 
-For repeated access, create a child profile extending `mistral-vibe`, add the path to its `filesystem.allow` or `filesystem.read`, validate it, and promote it outside the sandbox:
+For repeated access, create a child profile extending the user-provided active profile, add the path to its `filesystem.allow` or `filesystem.read`, validate it, and promote it outside the sandbox:
 
 ```bash
-nono profile init mistral-vibe-local --extends mistral-vibe --full
+nono profile init mistral-vibe-local --extends <active-profile> --full
 nono profile validate mistral-vibe-local
 nono profile promote mistral-vibe-local
 ```

--- a/omp/skills/nono-sandbox/SKILL.md
+++ b/omp/skills/nono-sandbox/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nono-sandbox
-description: Diagnose and resolve permission denials when Oh My Pi runs inside a nono security sandbox. Use this when a tool call, shell command, file operation, extension, package install, or provider request fails with "Operation not permitted", "Permission denied", EACCES, EPERM, landlock, or sandbox-denied errors.
+description: Diagnose confirmed nono sandbox denials for Oh My Pi. Generic permission failures require `nono why` or a clear non-sandbox diagnostic outcome before remediation.
 version: 1.0.0
 platforms: [macos, linux]
 ---
@@ -13,15 +13,14 @@ Oh My Pi cannot expand nono access from inside the session. Retries, approval pr
 
 ## When to use this skill
 
-Use this skill when an Oh My Pi tool, extension, package install, shell command, MCP subprocess, or provider request fails with:
+Use this skill to investigate a suspected nono denial. Only output that explicitly names nono as the denying sandbox is conclusive by itself. These markers signal sandbox enforcement but do not identify its provenance:
 
-- `Operation not permitted`
-- `Permission denied`
-- `EACCES` or `EPERM`
 - `landlock`
 - `sandbox: deny` or `sandbox denied`
 
 ## Diagnosis
+
+Generic `Operation not permitted`, `Permission denied`, `EACCES`, and `EPERM` are also ambiguous. With a concrete path, run `nono why --self`; a successful result with status `DENIED` confirms the nono boundary, even when the reason is `path_not_granted` and no policy source is reported. Otherwise report: `Nono sandbox unconfirmed; this permission failure needs a non-sandbox diagnosis.` Never infer the active profile; use the user's launch context or ask before drafting.
 
 1. Identify the concrete blocked path or network action from the failed tool call, stderr, traceback, or command arguments.
 2. Run:
@@ -46,7 +45,7 @@ Present exactly two options to the user.
 Use this for a path needed only once:
 
 ```bash
-nono run --profile omp --allow /path/to/needed -- omp
+nono run --profile <active-profile> --allow /path/to/needed -- omp
 ```
 
 Use `--read` instead of `--allow` when Oh My Pi only needs view access.
@@ -57,7 +56,7 @@ Create a profile draft under `~/.config/nono/profile-drafts/<name>.json`:
 
 ```json
 {
-  "extends": "omp",
+  "extends": "<active-profile>",
   "meta": { "name": "omp-extra", "version": "1.0.0" },
   "filesystem": {
     "read": ["/path/to/needed"]

--- a/openclaw/skills/nono-sandbox/SKILL.md
+++ b/openclaw/skills/nono-sandbox/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: nono-sandbox
-description: Diagnose and resolve permission denials when OpenClaw runs inside a nono security sandbox. Use this when a tool call, shell command, or file operation fails with "Operation not permitted", "Permission denied", EACCES, or EPERM — the cause is almost certainly the outer nono sandbox.
+description: Diagnose confirmed nono sandbox denials for OpenClaw. Generic permission failures require `nono why` or a clear non-sandbox diagnostic outcome before remediation.
 ---
 
-**On any EPERM / EACCES / "Operation not permitted" tool or shell failure:** run `nono why --self --path <blocked-path> --op read` immediately and include its output verbatim in your reply. Do NOT suggest sudo, chmod, or system permission changes. Then offer the user exactly these two options:
+Only output that explicitly names nono as the denying sandbox is conclusive by itself. `landlock` and `sandbox: deny` signal sandbox enforcement but do not identify its provenance; generic EPERM, EACCES, "Operation not permitted", and "Permission denied" are also ambiguous. With a concrete path, run `nono why --self --path <blocked-path> --op <needed-op>`; a successful result with status `DENIED` confirms the nono boundary, even when the reason is `path_not_granted` and no policy source is reported. If no path is available or `nono why` does not successfully report `DENIED`, report: `Nono sandbox unconfirmed; this permission failure needs a non-sandbox diagnosis.` Do not suggest sudo, chmod, or system permission changes, and offer the two options below, only after nono is confirmed:
 
-- **Option A (quick fix):** `nono run --allow /path/to/needed -- openclaw`
-- **Option B (persistent fix):** draft a profile to `~/.config/nono/profile-drafts/<name>.json` extending `openclaw`, add the path under `"allow"` or `"read"`, then tell the user to run `nono profile promote <name>` and start sessions with `nono run --profile <name> -- openclaw`
+- **Option A (quick fix):** restart with the user-provided active profile: `nono run --profile <active-profile> --allow /path/to/needed -- openclaw`
+- **Option B (persistent fix):** draft a profile to `~/.config/nono/profile-drafts/<name>.json` extending `<active-profile>`, add the path under `"allow"` or `"read"`, then tell the user to run `nono profile promote <name>` and start sessions with `nono run --profile <name> -- openclaw`
 
 # Working inside a nono sandbox
 
@@ -14,15 +14,12 @@ The user has launched you with `nono run --profile <name> -- openclaw`. nono enf
 
 ## Identifying a sandbox denial
 
-The denial signature is in the failed tool's output:
+These markers signal sandbox enforcement but do not identify nono as its provenance:
 
-- "Operation not permitted"
-- "Permission denied"
-- "EACCES" / "EPERM"
 - "landlock"
 - "sandbox: deny"
 
-When you see any of these on a file, shell, or tool failure, it is a nono boundary — not macOS TCC, not Full Disk Access, not Unix file permissions. Do NOT suggest:
+Never infer the active profile. Use a profile name supplied in the user's launch context, or ask which profile they started with before drafting. For a confirmed nono boundary, do NOT suggest:
 
 - System Settings / Privacy & Security
 - `chmod`, `chown`, `sudo`
@@ -54,7 +51,7 @@ The active profile directory `~/.config/nono/profiles/` is read-only from inside
 Write the JSON to `~/.config/nono/profile-drafts/<chosen-name>.json` extending the active profile. Minimal example for read-only access:
 
     {
-      "extends": "openclaw",
+      "extends": "<active-profile>",
       "meta": { "name": "<chosen-name>", "version": "1.0.0" },
       "filesystem": { "read": ["/path/to/needed"] }
     }

--- a/opencode/skills/nono-sandbox/SKILL.md
+++ b/opencode/skills/nono-sandbox/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: nono-sandbox
-description: Diagnose and resolve permission denials when opencode runs inside a nono security sandbox. Use this when a tool call, shell command, or file operation fails with "Operation not permitted", "Permission denied", EACCES, EPERM, landlock, or sandbox-denied errors, or when an outbound network request fails because the host is not on the sandbox allowlist (connection refused, timeout, or proxy/TLS errors).
+description: Diagnose confirmed nono sandbox denials for opencode. Generic permission failures require `nono why` or a clear non-sandbox diagnostic outcome before remediation; network diagnostics remain separate.
 version: 1.2.0
 platforms: [macos, linux]
 ---
 
-**On any EPERM / EACCES / "Operation not permitted" tool or shell failure:** run `nono why --self --path <blocked-path> --op read` immediately and include its output verbatim in your reply. Do NOT suggest sudo, chmod, or system permission changes. Then offer the user exactly these two options:
+Only output that explicitly names nono as the denying sandbox is conclusive by itself. `landlock` and `sandbox: deny` signal sandbox enforcement but do not identify its provenance; generic EPERM, EACCES, "Operation not permitted", and "Permission denied" are also ambiguous. With a concrete path, run `nono why --self --path <blocked-path> --op <needed-op>`; a successful result with status `DENIED` confirms the nono boundary, even when the reason is `path_not_granted` and no policy source is reported. If no path is available or `nono why` does not successfully report `DENIED`, report: `Nono sandbox unconfirmed; this permission failure needs a non-sandbox diagnosis.` Do not suggest sudo, chmod, or system permission changes, and offer the two options below, only after nono is confirmed:
 
-- **Option A (quick fix):** `nono run --allow /path/to/needed -- opencode`
-- **Option B (persistent fix):** draft a profile to `$XDG_CONFIG_HOME/nono/profile-drafts/<name>.json` extending `opencode`, add the path under `"allow"` or `"read"`, then tell the user to run `nono profile promote <name>` and start sessions with `nono run --profile <name> -- opencode`
+- **Option A (quick fix):** restart with the user-provided active profile: `nono run --profile <active-profile> --allow /path/to/needed -- opencode`
+- **Option B (persistent fix):** draft a profile to `$XDG_CONFIG_HOME/nono/profile-drafts/<name>.json` extending `<active-profile>`, add the path under `"allow"` or `"read"`, then tell the user to run `nono profile promote <name>` and start sessions with `nono run --profile <name> -- opencode`
 
 # Working inside a nono sandbox
 
@@ -16,15 +16,12 @@ The user has launched you with `nono run --profile <name> -- opencode`. nono enf
 
 ## Identifying a sandbox denial
 
-The denial signature is in the failed tool's output:
+These markers signal sandbox enforcement but do not identify nono as its provenance:
 
-- "Operation not permitted"
-- "Permission denied"
-- "EACCES" / "EPERM"
 - "landlock"
 - "sandbox: deny"
 
-When you see any of these on a file, shell, or tool failure, it is a nono boundary — not macOS TCC, not Full Disk Access, not Unix file permissions. Do NOT suggest:
+Never infer the active profile. Use a profile name supplied in the user's launch context, or ask which profile they started with before drafting. For a confirmed nono boundary, do NOT suggest:
 
 - System Settings / Privacy & Security
 - `chmod`, `chown`, `sudo`
@@ -62,7 +59,7 @@ The active profile directory `$XDG_CONFIG_HOME/nono/profiles/` is read-only from
 Write the JSON to `$XDG_CONFIG_HOME/nono/profile-drafts/<chosen-name>.json` extending the active profile. Minimal example for read-only access:
 
     {
-      "extends": "opencode",
+      "extends": "<active-profile>",
       "meta": { "name": "<chosen-name>", "version": "1.0.0" },
       "filesystem": { "read": ["/path/to/needed"] }
     }
@@ -99,7 +96,7 @@ If a host is genuinely needed, present the same two options as for filesystem de
 Add the host to `network.allow_domain` in a profile draft extending the active profile:
 
     {
-      "extends": "opencode",
+      "extends": "<active-profile>",
       "meta": { "name": "<chosen-name>", "version": "1.0.0" },
       "network": { "allow_domain": ["api.example.com"] }
     }

--- a/pi/skills/nono-sandbox/SKILL.md
+++ b/pi/skills/nono-sandbox/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nono-sandbox
-description: Diagnose and resolve permission denials when Pi Coding Agent runs inside a nono security sandbox. Use this when a tool call, shell command, file operation, extension, package install, or provider request fails with "Operation not permitted", "Permission denied", EACCES, EPERM, landlock, or sandbox-denied errors.
+description: Diagnose confirmed nono sandbox denials for Pi Coding Agent. Generic permission failures require `nono why` or a clear non-sandbox diagnostic outcome before remediation.
 version: 1.0.0
 platforms: [macos, linux]
 ---
@@ -13,15 +13,14 @@ Pi cannot expand nono access from inside the session. Retries, approval prompts,
 
 ## When to use this skill
 
-Use this skill when a Pi tool, extension, package install, shell command, MCP subprocess, or provider request fails with:
+Use this skill to investigate a suspected nono denial. Only output that explicitly names nono as the denying sandbox is conclusive by itself. These markers signal sandbox enforcement but do not identify its provenance:
 
-- `Operation not permitted`
-- `Permission denied`
-- `EACCES` or `EPERM`
 - `landlock`
 - `sandbox: deny` or `sandbox denied`
 
 ## Diagnosis
+
+Generic `Operation not permitted`, `Permission denied`, `EACCES`, and `EPERM` are also ambiguous. With a concrete path, run `nono why --self`; a successful result with status `DENIED` confirms the nono boundary, even when the reason is `path_not_granted` and no policy source is reported. Otherwise report: `Nono sandbox unconfirmed; this permission failure needs a non-sandbox diagnosis.` Never infer the active profile; use the user's launch context or ask before drafting.
 
 1. Identify the concrete blocked path or network action from the failed tool call, stderr, traceback, or command arguments.
 2. Run:
@@ -46,7 +45,7 @@ Present exactly two options to the user.
 Use this for a path needed only once:
 
 ```bash
-nono run --profile pi --allow /path/to/needed -- pi
+nono run --profile <active-profile> --allow /path/to/needed -- pi
 ```
 
 Use `--read` instead of `--allow` when Pi only needs view access.
@@ -57,7 +56,7 @@ Create a profile draft under `~/.config/nono/profile-drafts/<name>.json`:
 
 ```json
 {
-  "extends": "pi",
+  "extends": "<active-profile>",
   "meta": { "name": "pi-extra", "version": "1.0.0" },
   "filesystem": {
     "read": ["/path/to/needed"]


### PR DESCRIPTION
## Summary
- distinguish Nono provenance from generic permission failures and sandbox-enforcement markers
- confirm Nono through output that names Nono or a successful `nono why --self` result with status `DENIED`
- preserve a concrete non-sandbox diagnostic outcome when Nono cannot be confirmed
- stop inferring active profiles across affected pack guidance

## Why
`EPERM`, `EACCES`, `Permission denied`, and `Operation not permitted` do not identify their source. Even `landlock`, `sandbox: deny`, and Codex’s nested `sandbox-exec` failure establish only that a sandbox is involved—not that Nono is the enforcing sandbox.

The updated guidance uses `nono why --self` as the provenance check when a concrete path is available. A successful result whose status is `DENIED` confirms the Nono boundary, including ordinary `path_not_granted` results that have no policy source. Without that evidence, the guidance explicitly routes to a non-sandbox diagnosis. Confirmed Nono denials retain the existing narrow one-off and profile-draft remediation paths.

## Validation
- red-before content assertion against the base guidance
- green-after provenance/status assertions across all 12 corrected files
- parsed every package manifest and verified all declared artifact paths
- parsed `codex/wiring/codex-block.toml`
- `git diff --check`
- `hermes-gate fast` (PASS; receipt `4b4a26f1e04dbf4ab18d230cc242e3d8549f8ac25ea781ae4e7d0271f8ac3249`)