### PR TITLE
fix: name what changes a refused nested sandbox instead of path grants

### DIFF
--- a/claude/bin/nono-hook-bash.sh
+++ b/claude/bin/nono-hook-bash.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 # nono-hook-bash.sh - PostToolUse hook for Bash commands
-# Version: 1.1.0
+# Version: 1.2.0
 #
 # Inspects a Bash tool result for sandbox-denial patterns and injects
 # context so Claude can guide the user.
 #
+# 1.2.0: A refused sandbox re-initialization (sandbox_apply / sandbox_init
+# with EPERM, forbidden-sandbox-reinit) names no path, so it gets its own
+# context instead of the path-grant steps. The generic context no longer
+# asserts nono as the cause and requires a concrete path before `nono why`
+# or a grant is offered (nolabs-ai/nono#1646).
 # 1.1.0: Option B now points at ~/.config/nono/profile-drafts/ + promote
 # CLI, since profiles/ is no longer writable from inside the sandbox.
 
@@ -25,9 +30,32 @@ fi
 CAPS=$(jq -r '.fs[] | "  " + (.resolved // .path) + " (" + .access + ")"' "$NONO_CAP_FILE" 2>/dev/null)
 NET=$(jq -r 'if .net_blocked then "blocked" else "allowed" end' "$NONO_CAP_FILE" 2>/dev/null)
 
-CONTEXT="[NONO SANDBOX - PERMISSION DENIED]
+# A refused sandbox re-initialization is a different failure from a denied
+# path: macOS Seatbelt rejects sandbox_init() inside an already-sandboxed
+# process. No path grant, profile draft, or `nono why --path` query changes
+# it, so the path-grant steps must not run for it. The pattern is
+# order-independent, like the CLI classifier in
+# crates/nono-cli/src/diagnostic/formatter.rs (`looks_like_sandbox_reinit`).
+if echo "$OUTPUT" | grep -qiE '(sandbox_apply|sandbox_init).*(operation not permitted|EPERM)|(operation not permitted|EPERM).*(sandbox_apply|sandbox_init)|forbidden-sandbox-reinit'; then
+    CONTEXT="[NONO SANDBOX - NESTED SANDBOX REFUSED]
 
-This is a nono sandbox denial, not macOS TCC or a Unix permissions issue.
+The command tried to start its own sandbox (sandbox-exec / sandbox_init) inside nono's sandbox. macOS refuses sandbox re-initialization from an already-sandboxed process (forbidden-sandbox-reinit). This is not a denied path.
+
+Allowed paths (for reference only; none of them is the cause):
+$CAPS
+Network: $NET
+
+Do NOT run \`nono why --path\` for this failure: there is no blocked path to query. Do NOT offer \`nono run --allow\`, a profile draft, chmod, sudo, or System Settings: none of them changes this outcome.
+
+Tell the user what does change it:
+  - Run the tool with its built-in sandbox disabled, so nono stays the enforcement boundary (Codex: \`nono run --profile <name> -- codex --sandbox danger-full-access --ask-for-approval on-request\`).
+  - If the failing command was itself \`nono run\`, drop the inner nono: the outer sandbox already applies.
+
+Include the failing line verbatim in your reply."
+else
+    CONTEXT="[NONO SANDBOX - PERMISSION DENIAL SIGNATURE]
+
+The command output matched a permission-denial signature (EPERM, EACCES, \"Operation not permitted\", \"Permission denied\"). That signature alone does not identify the cause: it may be the nono sandbox boundary, or something nono did not decide. Do not assert nono as the cause until \`nono why\` confirms it.
 
 Allowed paths:
 $CAPS
@@ -35,8 +63,9 @@ Network: $NET
 
 DO NOT ask the user for permission. Take these steps in order, every time:
 
-1. Run \`nono why --self --path <blocked-path> --op read\` immediately. Include its output verbatim in your reply so the user sees the diagnosis.
-2. Then present the user with these two options as their NEXT decision point:
+1. If the failing output names a concrete path, run \`nono why --self --path <that-path> --op <read|write|readwrite>\` immediately and include its output verbatim in your reply. A result with status DENIED confirms the nono boundary, even when the reason is path_not_granted.
+2. If no concrete path is named, or \`nono why\` does not report DENIED, reply exactly: \`Nono sandbox unconfirmed; this permission failure needs a non-sandbox diagnosis.\` Do not invent a path, and do not offer the options below.
+3. Only for a confirmed DENIED path, present the user with these two options as their NEXT decision point:
 
    Option A (quick fix): exit and restart with the path allowed:
      nono run --allow /path/to/needed -- claude
@@ -44,7 +73,8 @@ DO NOT ask the user for permission. Take these steps in order, every time:
    Option B (persistent fix): draft a nono profile. The profiles/ directory is read-only from inside the sandbox; drafts go to profile-drafts/. Run \`nono profile guide\` for the schema (also without asking). If updating an existing user profile, read ~/.config/nono/profiles/<name>.json, compute the SHA-256 of those exact bytes, write the full proposed profile to ~/.config/nono/profile-drafts/<name>.json, and write the hash to ~/.config/nono/profile-drafts/<name>.base. If ~/.config/nono/profile-drafts does not exist or cannot be written, or \`nono profile promote --help\` is unavailable, do not try to modify profiles directly; tell the user to upgrade nono, then rerun the draft flow. If the current profile is pack-provided or built-in, draft <active>-local extending <active> instead of replacing it. Tell the user:
      Drafted <name>. Run \`nono profile promote <name>\` to review and apply, then start sessions with \`nono run --profile <name> -- claude\`.
 
-Step 1 is non-optional and must run before you reply. Do not ask whether to run it."
+Step 1 is non-optional whenever a path is named and must run before you reply. Do not ask whether to run it."
+fi
 
 jq -n --arg ctx "$CONTEXT" '{
   "hookSpecificOutput": {

--- a/claude/bin/nono-hook.sh
+++ b/claude/bin/nono-hook.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 # nono-hook.sh - Claude Code plugin hook for nono sandbox diagnostics
-# Version: 1.3.0
+# Version: 1.4.0
 #
 # Fires on PostToolUseFailure for Read|Write|Edit|Bash. Only injects
 # sandbox context when the failure looks like an actual sandbox denial.
 #
+# 1.4.0: A refused sandbox re-initialization (sandbox_apply / sandbox_init
+# with EPERM, forbidden-sandbox-reinit) names no path, so it gets its own
+# context instead of the path-grant steps. The generic context no longer
+# asserts nono as the cause and requires a concrete path before `nono why`
+# or a grant is offered (nolabs-ai/nono#1646).
 # 1.3.0: Option B now points at ~/.config/nono/profile-drafts/ + promote
 # CLI, since profiles/ is no longer writable from inside the sandbox.
 
@@ -25,9 +30,38 @@ fi
 CAPS=$(jq -r '.fs[] | "  " + (.resolved // .path) + " (" + .access + ")"' "$NONO_CAP_FILE" 2>/dev/null)
 NET=$(jq -r 'if .net_blocked then "blocked" else "allowed" end' "$NONO_CAP_FILE" 2>/dev/null)
 
-CONTEXT="[NONO SANDBOX - PERMISSION DENIED]
+# A refused sandbox re-initialization is a different failure from a denied
+# path: macOS Seatbelt rejects sandbox_init() inside an already-sandboxed
+# process. No path grant, profile draft, or `nono why --path` query changes
+# it, so the path-grant steps must not run for it.
+#
+# Match only the tool's own error text, not the whole hook payload: a file
+# being read or edited that merely mentions the signature must not trigger
+# this branch. If the payload carries no error text, fall through to the
+# generic branch, which asks for confirmation rather than asserting a cause.
+# The pattern is order-independent, like the CLI classifier in
+# crates/nono-cli/src/diagnostic/formatter.rs (`looks_like_sandbox_reinit`).
+ERROR_TEXT=$(echo "$INPUT" | jq -r '[.error, .tool_response, .tool_result] | map(select(. != null) | tostring) | join("\n")' 2>/dev/null)
+if echo "$ERROR_TEXT" | grep -qiE '(sandbox_apply|sandbox_init).*(operation not permitted|EPERM)|(operation not permitted|EPERM).*(sandbox_apply|sandbox_init)|forbidden-sandbox-reinit'; then
+    CONTEXT="[NONO SANDBOX - NESTED SANDBOX REFUSED]
 
-This is a nono sandbox denial, not macOS TCC or a Unix permissions issue.
+The tool tried to start its own sandbox (sandbox-exec / sandbox_init) inside nono's sandbox. macOS refuses sandbox re-initialization from an already-sandboxed process (forbidden-sandbox-reinit). This is not a denied path.
+
+Allowed paths (for reference only; none of them is the cause):
+$CAPS
+Network: $NET
+
+Do NOT run \`nono why --path\` for this failure: there is no blocked path to query. Do NOT offer \`nono run --allow\`, a profile draft, chmod, sudo, or System Settings: none of them changes this outcome.
+
+Tell the user what does change it:
+  - Run the tool with its built-in sandbox disabled, so nono stays the enforcement boundary (Codex: \`nono run --profile <name> -- codex --sandbox danger-full-access --ask-for-approval on-request\`).
+  - If the failing command was itself \`nono run\`, drop the inner nono: the outer sandbox already applies.
+
+Include the failing line verbatim in your reply."
+else
+    CONTEXT="[NONO SANDBOX - PERMISSION DENIAL SIGNATURE]
+
+The tool output matched a permission-denial signature (EPERM, EACCES, \"Operation not permitted\", \"Permission denied\"). That signature alone does not identify the cause: it may be the nono sandbox boundary, or something nono did not decide. Do not assert nono as the cause until \`nono why\` confirms it.
 
 Allowed paths:
 $CAPS
@@ -35,8 +69,9 @@ Network: $NET
 
 DO NOT ask the user for permission. Take these steps in order, every time:
 
-1. Run \`nono why --self --path <blocked-path> --op read\` immediately. Include its output verbatim in your reply so the user sees the diagnosis.
-2. Then present the user with these two options as their NEXT decision point:
+1. If the failing output names a concrete path, run \`nono why --self --path <that-path> --op <read|write|readwrite>\` immediately and include its output verbatim in your reply. A result with status DENIED confirms the nono boundary, even when the reason is path_not_granted.
+2. If no concrete path is named, or \`nono why\` does not report DENIED, reply exactly: \`Nono sandbox unconfirmed; this permission failure needs a non-sandbox diagnosis.\` Do not invent a path, and do not offer the options below.
+3. Only for a confirmed DENIED path, present the user with these two options as their NEXT decision point:
 
    Option A (quick fix): exit and restart with the path allowed:
      nono run --allow /path/to/needed -- claude
@@ -44,7 +79,8 @@ DO NOT ask the user for permission. Take these steps in order, every time:
    Option B (persistent fix): draft a nono profile. The profiles/ directory is read-only from inside the sandbox; drafts go to profile-drafts/. Run \`nono profile guide\` for the schema (also without asking). If updating an existing user profile, read ~/.config/nono/profiles/<name>.json, compute the SHA-256 of those exact bytes, write the full proposed profile to ~/.config/nono/profile-drafts/<name>.json, and write the hash to ~/.config/nono/profile-drafts/<name>.base. If ~/.config/nono/profile-drafts does not exist or cannot be written, or \`nono profile promote --help\` is unavailable, do not try to modify profiles directly; tell the user to upgrade nono, then rerun the draft flow. If the current profile is pack-provided or built-in, draft <active>-local extending <active> instead of replacing it. Tell the user:
      Drafted <name>. Run \`nono profile promote <name>\` to review and apply, then start sessions with \`nono run --profile <name> -- claude\`.
 
-Step 1 is non-optional and must run before you reply. Do not ask whether to run it."
+Step 1 is non-optional whenever a path is named and must run before you reply. Do not ask whether to run it."
+fi
 
 jq -n --arg ctx "$CONTEXT" '{
   "hookSpecificOutput": {

--- a/claude/skills/nono-sandbox/SKILL.md
+++ b/claude/skills/nono-sandbox/SKILL.md
@@ -27,6 +27,10 @@ Output that explicitly names nono as the denying sandbox is conclusive. `landloc
    - Suggesting the user run commands manually from another terminal
 3. **Do NOT apologize repeatedly** or suggest you will "try another approach" - there is no other approach.
 
+## Refused nested sandbox (names no path)
+
+`sandbox-exec: sandbox_apply: Operation not permitted`, a `sandbox_init` failure with EPERM, or `forbidden-sandbox-reinit` means a tool tried to start its own macOS sandbox inside nono's sandbox and Seatbelt refused. This denial names no path. Do not run `nono why --path` for it, and do not offer `nono run --allow`, a profile draft, chmod, or sudo: none of them changes the outcome. Tell the user what does: run the tool with its built-in sandbox disabled so nono stays the enforcement boundary (Codex: `nono run --profile <name> -- codex --sandbox danger-full-access --ask-for-approval on-request`), or, if the failing command was itself `nono run`, drop the inner nono because the outer sandbox already applies.
+
 ## Diagnosing the denial
 
 Run `nono why` to understand exactly why the operation was blocked:

--- a/codex/skills/nono-sandbox/SKILL.md
+++ b/codex/skills/nono-sandbox/SKILL.md
@@ -15,7 +15,7 @@ Only output that explicitly names nono as the denying sandbox is conclusive by i
 - "landlock"
 - "sandbox: deny"
 
-On macOS, `sandbox-exec: sandbox_apply: Operation not permitted` can mean Codex tried to apply its own sandbox inside another Seatbelt sandbox; investigate it as a sandbox conflict without assuming nono caused it.
+On macOS, `sandbox-exec: sandbox_apply: Operation not permitted` means Codex tried to apply its own Seatbelt sandbox inside an already-sandboxed process and the kernel refused (`forbidden-sandbox-reinit`). It names no path: do not run `nono why --path` for it, and do not offer Option A or Option B, because no path grant or profile change alters it. What does: restart Codex with its built-in sandbox disabled so nono stays the enforcement boundary, `nono run --profile <name> -- codex --sandbox danger-full-access --ask-for-approval on-request`. Tell the user exactly that.
 
 Generic `Operation not permitted`, `Permission denied`, `EACCES`, and `EPERM` are also ambiguous. If a concrete path is available, run `nono why --self --path <path> --op <needed-op>`; a successful result with status `DENIED` confirms the nono boundary, even when the reason is `path_not_granted` and no policy source is reported. If the path is unavailable or `nono why` does not successfully report `DENIED`, report: `Nono sandbox unconfirmed; this permission failure needs a non-sandbox diagnosis.` Do not offer a profile change until nono is confirmed.
 

--- a/codex/wiring/codex-block.toml
+++ b/codex/wiring/codex-block.toml
@@ -1,6 +1,8 @@
 developer_instructions = """
 Only output that explicitly names nono as the denying sandbox is conclusive by itself. `sandbox-exec: sandbox_apply: Operation not permitted`, `landlock`, and `sandbox denied` signal sandbox enforcement but do not identify its provenance; generic `Operation not permitted`, `Permission denied`, `EACCES`, and `EPERM` are also ambiguous. When a concrete path is known, run `nono why --self --path <path> --op <needed-op>`; a successful result with status `DENIED` confirms the nono boundary, even when the reason is `path_not_granted` and no policy source is reported. If no path is available or `nono why` does not successfully report `DENIED`, report: `Nono sandbox unconfirmed; this permission failure needs a non-sandbox diagnosis.`
 
+`sandbox-exec: sandbox_apply: Operation not permitted` is different: Codex tried to apply its own Seatbelt sandbox inside an already-sandboxed process and the kernel refused (`forbidden-sandbox-reinit`). It names no path. Do not run `nono why --path` for it and do not offer options A or B; no path grant or profile change alters it. Tell the user to restart Codex with its built-in sandbox disabled so nono stays the enforcement boundary: `nono run --profile <name> -- codex --sandbox danger-full-access --ask-for-approval on-request`.
+
 For a confirmed nono denial, do not suggest System Settings, Full Disk Access, chmod, chown, sudo, or bypassing Codex permissions. Explain that nono must be restarted with the needed capability.
 
 Only after confirming a nono denial, offer exactly these options:


### PR DESCRIPTION
A tool that starts its own macOS sandbox inside nono fails with
`sandbox-exec: sandbox_apply: Operation not permitted`
(`forbidden-sandbox-reinit`). That denial names no path, but the Claude
hooks matched it with the generic EPERM/EACCES gate and injected
"This is a nono sandbox denial ... run `nono why --self --path
<blocked-path>` ... restart with `nono run --allow /path/to/needed`",
which pre-commits the agent to a path diagnosis and a grant that cannot
change the outcome.

- Claude hooks: route the re-initialization signature to its own context
  that says there is no path to query or grant, and names what does
  change the outcome (disable the tool's built-in sandbox so nono stays
  the boundary; drop an inner `nono run`). The generic context no longer
  asserts nono as the cause, requires a concrete path before `nono why`
  or a grant is offered, and otherwise reports the sandbox as
  unconfirmed, matching the SKILL.md wording from #29.
- Claude and Codex skills, Codex developer instructions: describe the
  refusal as a non-path denial with the same remedy instead of an
  unattributed "sandbox conflict".

Other packs still carry the broad wording and are left for a follow-up.

Refs nolabs-ai/nono#1646; companion to nolabs-ai/nono PR "fix(cli): classify a refused sandbox re-initialization as a non-path denial" (branch roli-lpci:fix/1646-sandbox-reinit-guidance), which makes the CLI's own diagnostics say the same thing.

<!-- hermes-labs:attribution v1 -->
This contribution was produced by agents through [Hermes Labs](https://hermes-labs.ai)’ engineering infrastructure. [Rolando Bosch](https://github.com/roli-lpci) is the responsible human contributor and authorized publication from his personal GitHub account.
<!-- /hermes-labs:attribution -->
